### PR TITLE
Feature/saving deposit withdraw

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -67,6 +67,7 @@ import Scan from './screens/scan/Scan'
 // Invest Screens
 import Savings from './screens/invest/Savings'
 import StockDetail from './screens/invest/StockDetail'
+import SavingsKeypad from './screens/invest/SavingsKeypad'
 
 // InOut Screens
 import Add from './screens/add/Add'
@@ -350,6 +351,16 @@ const AppNavigator = ({ pendingDeepLinkRef }: { pendingDeepLinkRef: React.RefObj
 				name={ROUTES.SAVINGS_SCREEN}
 				component={Savings}
 				options={getHeaderOptions('Ahorros')}
+			/>
+			<Stack.Screen
+				name={ROUTES.SAVINGS_DEPOSIT}
+				component={SavingsKeypad}
+				options={getHeaderOptions('Depositar en ahorros')}
+			/>
+			<Stack.Screen
+				name={ROUTES.SAVINGS_WITHDRAW}
+				component={SavingsKeypad}
+				options={getHeaderOptions('Retirar de ahorros')}
 			/>
 
 			{/* Stock Detail Screen */}

--- a/routes.js
+++ b/routes.js
@@ -78,6 +78,8 @@ export const ROUTES = {
 
     // Invest Screens
     SAVINGS_SCREEN: "Savings",
+    SAVINGS_DEPOSIT: "SavingsDeposit",
+    SAVINGS_WITHDRAW: "SavingsWithdraw",
     STOCK_DETAIL_SCREEN: "StockDetail",
 
     // Help Screens

--- a/screens/invest/Savings.jsx
+++ b/screens/invest/Savings.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
+import { useFocusEffect } from '@react-navigation/native'
 import { View, Text, StyleSheet, ScrollView, Linking } from 'react-native'
 
 // Theme
@@ -21,16 +22,15 @@ import { ROUTES } from '../../routes'
 // Helpers
 import { timeAgo } from '../../helpers'
 
-const Savings = ({ route }) => {
+const Savings = ({ navigation }) => {
 
 	const { theme } = useTheme()
 	const containerStyles = useContainerStyles(theme)
 	const textStyles = useTextStyles(theme)
 
-	// Use params if passed from Invest, otherwise fetch
-	const [savings, setSavings] = useState(route.params?.savings || null)
+	const [savings, setSavings] = useState(null)
 	const [transactions, setTransactions] = useState([])
-	const [isLoading, setIsLoading] = useState(!route.params?.savings)
+	const [isLoading, setIsLoading] = useState(true)
 
 	const fetchSavings = useCallback(async () => {
 		setIsLoading(true)
@@ -46,14 +46,9 @@ const Savings = ({ route }) => {
 		} finally { setIsLoading(false) }
 	}, [])
 
-	useEffect(() => {
-		if (!route.params?.savings) {
-			fetchSavings()
-		} else {
-			// Still fetch transactions even if summary was passed
-			savingApi.getTransactions(20).then(res => { if (res.success && Array.isArray(res.data)) setTransactions(res.data) })
-		}
-	}, [route.params?.savings, fetchSavings])
+	useFocusEffect(
+		useCallback(() => { fetchSavings() }, [fetchSavings])
+	)
 
 	if (isLoading) return <QPLoader />
 
@@ -86,16 +81,17 @@ const Savings = ({ route }) => {
 					<QPButton
 						title="Depositar"
 						icon="arrow-down"
-						onPress={() => { }}
+						onPress={() => navigation.navigate(ROUTES.SAVINGS_DEPOSIT, { mode: 'savings_deposit' })}
 						style={styles.actionButton}
 					/>
 					<QPButton
 						title="Retirar"
 						icon="arrow-up"
-						onPress={() => { }}
+						onPress={() => navigation.navigate(ROUTES.SAVINGS_WITHDRAW, { mode: 'savings_withdraw', savingsBalance: Number(balance) })}
 						style={styles.actionButton}
 						outlined
 						danger={false}
+						disabled={Number(balance) === 0}
 					/>
 				</View>
 

--- a/screens/invest/SavingsKeypad.jsx
+++ b/screens/invest/SavingsKeypad.jsx
@@ -1,0 +1,12 @@
+import { View, Platform } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Keypad from '../keypad/Keypad'
+
+export default function SavingsKeypad({ navigation, route }) {
+	const insets = useSafeAreaInsets()
+	return (
+		<View style={{ flex: 1, paddingBottom: Platform.OS === 'android' ? insets.bottom : 0 }}>
+			<Keypad navigation={navigation} route={route} />
+		</View>
+	)
+}

--- a/screens/keypad/Keypad.jsx
+++ b/screens/keypad/Keypad.jsx
@@ -26,6 +26,9 @@ import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 // Routes
 import { ROUTES } from '../../routes'
 
+// API
+import { savingApi } from '../../api/savingApi'
+
 // Toast
 import { toast } from 'sonner-native'
 
@@ -38,12 +41,18 @@ const FONT_SIZE_DECREASE_FACTOR = 4
 const ANIMATION_DURATION = 150
 const VIBRATION_DURATION = 50
 
-export default function Keypad({ navigation }) {
+export default function Keypad({ navigation, route }) {
 
 	// Contexts
 	const { user } = useAuth()
 	const { theme } = useTheme()
 	const insets = useSafeAreaInsets()
+
+	// Savings mode params
+	const mode = route?.params?.mode  // 'savings_deposit' | 'savings_withdraw' | undefined
+	const savingsBalance = route?.params?.savingsBalance
+	const isSavingsMode = mode === 'savings_deposit' || mode === 'savings_withdraw'
+	const displayBalance = mode === 'savings_withdraw' ? savingsBalance : user?.balance
 
 	// State
 	const [amount, setAmount] = useState('0')
@@ -155,8 +164,8 @@ export default function Keypad({ navigation }) {
 	// Set maximum balance
 	const setMaxBalance = useCallback(() => {
 
-		if (!user?.balance) return
-		const maxAmount = user.balance.toString()
+		if (!displayBalance) return
+		const maxAmount = displayBalance.toString()
 		setAmount(maxAmount)
 		const newFontSize = calculateFontSize(maxAmount)
 		animateFontSize(newFontSize)
@@ -165,7 +174,7 @@ export default function Keypad({ navigation }) {
 		// Announce to screen reader
 		AccessibilityInfo.announceForAccessibility(`Set to maximum balance: $${maxAmount}`)
 
-	}, [user?.balance, calculateFontSize, animateFontSize, triggerHapticFeedback])
+	}, [displayBalance, calculateFontSize, animateFontSize, triggerHapticFeedback])
 
 	// Send amount
 	const handleSendAmount = useCallback(async () => {
@@ -192,6 +201,40 @@ export default function Keypad({ navigation }) {
 		} finally { setIsProcessing(false) }
 
 	}, [amount, user?.balance, isProcessing, navigation])
+
+	// Savings deposit or withdraw
+	const handleSavingsAction = useCallback(async () => {
+
+		if (isProcessing) return
+		const numericAmount = parseFloat(amount)
+
+		if (numericAmount <= 0) {
+			toast.error('Monto inválido', { description: 'El monto debe ser mayor a 0' })
+			return
+		}
+
+		if (displayBalance !== undefined && numericAmount > displayBalance) {
+			toast.error('Saldo insuficiente', { description: 'El monto supera tu saldo disponible' })
+			return
+		}
+
+		setIsProcessing(true)
+		try {
+			const result = mode === 'savings_deposit'
+				? await savingApi.deposit(numericAmount)
+				: await savingApi.withdraw(numericAmount)
+
+			if (result.success) {
+				toast.success(mode === 'savings_deposit' ? 'Depósito exitoso' : 'Retiro exitoso')
+				navigation.goBack()
+			} else {
+				toast.error(result.error || 'Error al procesar')
+			}
+		} catch {
+			toast.error('Error inesperado')
+		} finally { setIsProcessing(false) }
+
+	}, [amount, displayBalance, mode, isProcessing, navigation])
 
 	// Receive amount
 	const handleReceiveAmount = useCallback(() => {
@@ -251,11 +294,11 @@ export default function Keypad({ navigation }) {
 					style={[styles.balanceContainer, { backgroundColor: theme.colors.elevation }]}
 					onPress={setMaxBalance}
 					accessibilityRole="button"
-					accessibilityLabel={`Current balance: $${user?.balance || 0}`}
+					accessibilityLabel={`Current balance: $${displayBalance ?? user?.balance ?? 0}`}
 					accessibilityHint="Double tap to set amount to maximum balance"
 				>
 					<Text style={[styles.balanceText, { color: theme.colors.primaryText, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.medium }]}>
-						${user?.balance || 0}
+						${displayBalance ?? user?.balance ?? 0}
 					</Text>
 				</Pressable>
 			</View>
@@ -271,27 +314,54 @@ export default function Keypad({ navigation }) {
 
 			{/* Action Buttons */}
 			<View style={styles.actionSection}>
-				<QPButton
-					title="Recibir"
-					onPress={handleReceiveAmount}
-					disabled={isProcessing}
-					icon="arrow-down"
-					style={[styles.actionButton, { backgroundColor: theme.colors.elevation }, isProcessing && styles.actionButtonDisabled]}
-					iconColor={theme.colors.contrast}
-					textStyle={{ color: theme.colors.contrast }}
-					iconStyle="solid"
-				/>
-				<View style={styles.actionButtonSpacer} />
-				<QPButton
-					title={'Enviar'}
-					onPress={handleSendAmount}
-					disabled={isProcessing}
-					icon="arrow-up"
-					style={[styles.actionButton, { backgroundColor: theme.colors.primary }, isProcessing && styles.actionButtonDisabled]}
-					iconColor={theme.colors.almostWhite}
-					textStyle={{ color: theme.colors.almostWhite }}
-					iconStyle="solid"
-				/>
+				{isSavingsMode ? (
+					<>
+						<QPButton
+							title="Cancelar"
+							onPress={navigation.goBack}
+							disabled={isProcessing}
+							style={[styles.actionButton, { backgroundColor: theme.colors.elevation }, isProcessing && styles.actionButtonDisabled]}
+							iconColor={theme.colors.contrast}
+							textStyle={{ color: theme.colors.contrast }}
+						/>
+						<View style={styles.actionButtonSpacer} />
+						<QPButton
+							title={mode === 'savings_deposit' ? 'Depositar' : 'Retirar'}
+							onPress={handleSavingsAction}
+							loading={isProcessing}
+							disabled={isProcessing}
+							icon={mode === 'savings_deposit' ? 'arrow-down' : 'arrow-up'}
+							style={[styles.actionButton, { backgroundColor: theme.colors.primary }, isProcessing && styles.actionButtonDisabled]}
+							iconColor={theme.colors.almostWhite}
+							textStyle={{ color: theme.colors.almostWhite }}
+							iconStyle="solid"
+						/>
+					</>
+				) : (
+					<>
+						<QPButton
+							title="Recibir"
+							onPress={handleReceiveAmount}
+							disabled={isProcessing}
+							icon="arrow-down"
+							style={[styles.actionButton, { backgroundColor: theme.colors.elevation }, isProcessing && styles.actionButtonDisabled]}
+							iconColor={theme.colors.contrast}
+							textStyle={{ color: theme.colors.contrast }}
+							iconStyle="solid"
+						/>
+						<View style={styles.actionButtonSpacer} />
+						<QPButton
+							title={'Enviar'}
+							onPress={handleSendAmount}
+							disabled={isProcessing}
+							icon="arrow-up"
+							style={[styles.actionButton, { backgroundColor: theme.colors.primary }, isProcessing && styles.actionButtonDisabled]}
+							iconColor={theme.colors.almostWhite}
+							textStyle={{ color: theme.colors.almostWhite }}
+							iconStyle="solid"
+						/>
+					</>
+				)}
 			</View>
 		</View>
 	)


### PR DESCRIPTION
## Savings Deposit & Withdraw screens

### Overview

Implements the Deposit and Withdraw flows for the Savings section of the Invest tab. Tapping either button navigates to a keypad screen where the user enters an amount, which is then submitted to the savings API. Also fixes a safe-area layout issue on Android devices with on-screen navigation buttons.

---

### Changes

#### `routes.js`
Added two new named routes: `SAVINGS_DEPOSIT` and `SAVINGS_WITHDRAW`. These were referenced in `Savings.jsx` button handlers and needed to be formally declared before registering them in the navigator.

#### `screens/invest/Savings.jsx`
- Swapped `useEffect` for `useFocusEffect` so the balance and transaction list refresh every time the user returns to the screen (e.g. after completing a deposit or withdrawal), not just on mount.
- Removed the previous pattern of accepting pre-fetched savings data via `route.params`. The screen now always fetches its own data, which simplifies the data flow and prevents stale state after an operation.
- Wired up the **Depositar** and **Retirar** buttons to navigate to the new routes, passing `mode` and (for withdraw) `savingsBalance` as params.
- Added `disabled` to the Retirar button when the savings balance is zero, preventing a pointless withdraw flow.
- Destructured `navigation` from props (was previously unused for these actions).

#### `screens/keypad/Keypad.jsx`
Extended the existing keypad to support a savings mode without breaking its default send/receive behaviour:

- Reads `mode` (`'savings_deposit'` | `'savings_withdraw'`) and `savingsBalance` from `route.params`.
- Derives `displayBalance`: savings balance for withdraw mode, wallet balance otherwise. This value drives the "max" shortcut and the displayed balance pill — fixing a bug where the pill always showed `user?.balance` even in savings withdraw mode.
- Added `handleSavingsAction`: calls `savingApi.deposit()` or `savingApi.withdraw()` based on `mode`, shows success/error toasts, and navigates back on success.
- When `isSavingsMode` is true the bottom action bar renders **Cancelar** + **Depositar/Retirar** instead of the default **Recibir** + **Enviar** pair.

#### `screens/invest/SavingsKeypad.jsx` *(new)*
A thin wrapper screen that sits between the navigator and `Keypad` for the two savings routes only. It applies `paddingBottom: insets.bottom` on Android to respect devices with on-screen navigation buttons.

This is intentionally a wrapper rather than a change inside `Keypad` itself: `Keypad` is shared across send, receive, and savings flows. Adding platform-specific safe-area logic for one flow inside the component would have introduced side effects on all others. The wrapper keeps the concern scoped to the routes that need it.

iOS is excluded from the wrapper's padding because `Keypad` already handles its own bottom inset for iOS 26+ (liquid glass home bar).

#### `App.tsx`
- Registered `SAVINGS_DEPOSIT` and `SAVINGS_WITHDRAW` as stack screens pointing to `SavingsKeypad`, with appropriate header titles.
- Imported `SavingsKeypad`; the top-level `Keypad` import was removed as it is no longer used directly at this navigator level.