### PR TITLE
Refactor Home screen to React Query with section-level components/hooks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 
 // OneSignal Push Notifications
 import { OneSignal } from 'react-native-onesignal'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // Navigation Components
 import { enableFreeze } from 'react-native-screens'
@@ -578,37 +579,40 @@ const LoadingBridge = ({ children }: { children: React.ReactNode }) => {
 
 // Initialize OneSignal (must be called outside component, before render)
 OneSignal.initialize('8f69c017-b7e7-40b2-903b-11ce7ac5cc81')
+const queryClient = new QueryClient()
 
 function App() {
 	const pendingDeepLinkRef = useRef<string | null>(null)
 
 	return (
-		<GestureHandlerRootView style={{ flex: 1 }}>
-			<ErrorBoundary>
-				<SafeAreaProvider>
-					<LoadingProvider>
-						<AuthProvider>
-							<OnlineStatusProvider>
-								<SettingsProvider>
-									<ThemeProviderWithSettings>
-										<LoadingBridge>
-											<AppLockProvider>
-												<NavigationWrapper>
-													<GlobalLoadingBar />
-													<AppNavigator pendingDeepLinkRef={pendingDeepLinkRef} />
-													<Toaster position="top-center" />
-												</NavigationWrapper>
-												<LockScreen />
-											</AppLockProvider>
-										</LoadingBridge>
-									</ThemeProviderWithSettings>
-								</SettingsProvider>
-							</OnlineStatusProvider>
-						</AuthProvider>
-					</LoadingProvider>
-				</SafeAreaProvider>
-			</ErrorBoundary>
-		</GestureHandlerRootView>
+		<QueryClientProvider client={queryClient}>
+			<GestureHandlerRootView style={{ flex: 1 }}>
+				<ErrorBoundary>
+					<SafeAreaProvider>
+						<LoadingProvider>
+							<AuthProvider>
+								<OnlineStatusProvider>
+									<SettingsProvider>
+										<ThemeProviderWithSettings>
+											<LoadingBridge>
+												<AppLockProvider>
+													<NavigationWrapper>
+														<GlobalLoadingBar />
+														<AppNavigator pendingDeepLinkRef={pendingDeepLinkRef} />
+														<Toaster position="top-center" />
+													</NavigationWrapper>
+													<LockScreen />
+												</AppLockProvider>
+											</LoadingBridge>
+										</ThemeProviderWithSettings>
+									</SettingsProvider>
+								</OnlineStatusProvider>
+							</AuthProvider>
+						</LoadingProvider>
+					</SafeAreaProvider>
+				</ErrorBoundary>
+			</GestureHandlerRootView>
+		</QueryClientProvider>
 	)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "QvaPay",
-  "version": "1.5.11",
+  "version": "1.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "QvaPay",
-      "version": "1.5.11",
+      "version": "1.5.13",
       "dependencies": {
         "@adrianso/react-native-device-brightness": "^1.2.7",
         "@d11/react-native-fast-image": "^8.13.0",
@@ -18,6 +18,7 @@
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "@shopify/flash-list": "^2.3.1",
+        "@tanstack/react-query": "^5.100.1",
         "axios": "^1.14.0",
         "lottie-react-native": "^7.3.6",
         "react": "^19.2.4",
@@ -251,7 +252,7 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
       "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -341,7 +342,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
       "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
@@ -416,7 +417,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
       "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -543,7 +544,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.27.1.tgz",
       "integrity": "sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -623,7 +624,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -636,7 +637,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.27.1.tgz",
       "integrity": "sha512-eBC/3KSekshx19+N40MzjWqJd7KTEdOoLesAfa4IDFI8eRz5a47i5Oszus6zG/cwIXN63YhgLOMSSNJx49sENg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -652,7 +653,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -887,7 +888,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
       "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -905,7 +906,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
       "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -939,7 +940,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
       "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -955,7 +956,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
       "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -989,7 +990,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
       "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1010,7 +1011,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
       "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -1027,7 +1028,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
       "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1159,7 +1160,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
       "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1176,7 +1177,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
       "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1193,7 +1194,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
       "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.1",
@@ -1227,7 +1228,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
       "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1243,7 +1244,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
       "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1344,7 +1345,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
       "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1377,7 +1378,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
       "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1393,7 +1394,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
       "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1409,7 +1410,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
       "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -1446,7 +1447,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
       "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1462,7 +1463,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
       "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -1479,7 +1480,7 @@
       "version": "7.27.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
       "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1495,7 +1496,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
       "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -1512,7 +1513,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
       "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1546,7 +1547,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
       "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1562,7 +1563,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
@@ -1582,7 +1583,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1598,7 +1599,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1614,7 +1615,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
       "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1663,7 +1664,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
       "integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -1699,7 +1700,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
       "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -1716,7 +1717,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
       "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2229,14 +2230,14 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -4516,7 +4517,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-20.1.3.tgz",
       "integrity": "sha512-sLo8cu9JyFNfuuF1C+8NJ4DHE/PEFaXGd4enkcxi/OJjGG8+sOQrdjNQ4i+cVh/2c+ah1mEMwsYjc3z0+/MqSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-clean": "20.1.3",
@@ -4546,7 +4547,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-20.1.3.tgz",
       "integrity": "sha512-sFLdLzapfC0scjgzBJJWYDY2RhHPjuuPkA5r6q0gc/UQH/izXpMpLrhh1DW84cMDraNACK0U62tU7ebNaQ1LMQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-tools": "20.1.3",
@@ -4559,7 +4560,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-20.1.3.tgz",
       "integrity": "sha512-n73nW0cG92oNF0r994pPqm0DjAShOm3F8LSffDYhJqNAno+h/csmv/37iL4NtSpmKIO8xqsG3uVTXz9X/hzNaQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-tools": "20.1.3",
@@ -4574,7 +4575,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-config-android/-/cli-config-android-20.1.3.tgz",
       "integrity": "sha512-DNHDP+OWLyhKShGciBqPcxhxfp1Z/7GQcb4F+TGyCeKQAr+JdnUjRXN3X+YCU/v+g2kbYYyRJKlGabzkVvdrAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-tools": "20.1.3",
@@ -4587,7 +4588,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-config-apple/-/cli-config-apple-20.1.3.tgz",
       "integrity": "sha512-QX9B83nAfCPs0KiaYz61kAEHWr9sttooxzRzNdQwvZTwnsIpvWOT9GvMMj/19OeXiQzMJBzZX0Pgt6+spiUsDQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-tools": "20.1.3",
@@ -4600,7 +4601,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-20.1.3.tgz",
       "integrity": "sha512-EI+mAPWn255/WZ4CQohy1I049yiaxVr41C3BeQ2BCyhxODIDR8XRsLzYb1t9MfqK/C3ZncUN2mPSRXFeKPPI1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-config": "20.1.3",
@@ -4624,7 +4625,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4637,7 +4638,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-20.1.3.tgz",
       "integrity": "sha512-bzB9ELPOISuqgtDZXFPQlkuxx1YFkNx3cNgslc5ElCrk+5LeCLQLIBh/dmIuK8rwUrPcrramjeBj++Noc+TaAA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-config-android": "20.1.3",
@@ -4651,7 +4652,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-20.1.3.tgz",
       "integrity": "sha512-XJ+DqAD4hkplWVXK5AMgN7pP9+4yRSe5KfZ/b42+ofkDBI55ALlUmX+9HWE3fMuRjcotTCoNZqX2ov97cFDXpQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-config-apple": "20.1.3",
@@ -4665,7 +4666,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-20.1.3.tgz",
       "integrity": "sha512-2qL48SINotuHbZO73cgqSwqd/OWNx0xTbFSdujhpogV4p8BNwYYypfjh4vJY5qJEB5PxuoVkMXT+aCADpg9nBg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-platform-apple": "20.1.3"
@@ -4675,7 +4676,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-20.1.3.tgz",
       "integrity": "sha512-hsNsdUKZDd2T99OuNuiXz4VuvLa1UN0zcxefmPjXQgI0byrBLzzDr+o7p03sKuODSzKi2h+BMnUxiS07HACQLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-tools": "20.1.3",
@@ -4695,7 +4696,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-20.1.3.tgz",
       "integrity": "sha512-EAn0vPCMxtHhfWk2UwLmSUfPfLUnFgC7NjiVJVTKJyVk5qGnkPfoT8te/1IUXFTysUB0F0RIi+NgDB4usFOLeA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/sudo-prompt": "^9.0.0",
@@ -4714,7 +4715,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4727,7 +4728,7 @@
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-20.1.3.tgz",
       "integrity": "sha512-IdAcegf0pH1hVraxWTG1ACLkYC0LDQfqtaEf42ESyLIF3Xap70JzL/9tAlxw7lSCPZPFWhrcgU0TBc4SkC/ecw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "joi": "^17.2.1"
@@ -4737,7 +4738,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4885,7 +4886,7 @@
       "version": "0.83.1",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.1.tgz",
       "integrity": "sha512-VPj8O3pG1ESjZho9WVKxqiuryrotAECPHGF5mx46zLUYNTWR5u9OMUXYk7LeLy+JLWdGEZ2Gn3KoXeFZbuqE+g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -4899,7 +4900,7 @@
       "version": "0.83.1",
       "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.83.1.tgz",
       "integrity": "sha512-xI+tbsD4fXcI6PVU4sauRCh0a5fuLQC849SINmU2J5wP8kzKu4Ye0YkGjUW3mfGrjaZcjkWmF6s33jpyd3gdTw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -5203,7 +5204,7 @@
       "version": "0.83.1",
       "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz",
       "integrity": "sha512-fqt6DHWX1GBGDKa5WJOjDtPPy2M9lkYVLn59fBeFQ0GXhBRzNbUh8JzWWI/Q2CLDZ2tgKCcwaiXJ1OHWVd2BCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -5222,7 +5223,7 @@
       "version": "0.83.1",
       "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.83.1.tgz",
       "integrity": "sha512-1rjYZf62fCm6QAinHmRAKnJxIypX0VF/zBPd0qWvWABMZugrS0eACuIbk9Wk0StBod4yL8KnwEJyg77ak8xYzQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@react-native/js-polyfills": "0.83.1",
@@ -5390,7 +5391,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
       "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -5400,14 +5401,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
       "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
@@ -5757,6 +5758,32 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.1.tgz",
+      "integrity": "sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.1.tgz",
+      "integrity": "sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5927,7 +5954,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6500,7 +6527,7 @@
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
@@ -6646,7 +6673,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz",
       "integrity": "sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^1.0.7",
@@ -6658,7 +6685,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6668,7 +6695,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
@@ -6718,14 +6745,14 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.7.tgz",
       "integrity": "sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -6884,7 +6911,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6904,7 +6931,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -7020,7 +7047,7 @@
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
       "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -7035,7 +7062,7 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
       "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.5",
@@ -7049,7 +7076,7 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
       "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.8"
@@ -7071,7 +7098,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
       "integrity": "sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
@@ -7166,7 +7193,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -7178,7 +7205,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -7293,7 +7320,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7324,7 +7351,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7381,7 +7408,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7539,7 +7566,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -7552,7 +7579,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7647,7 +7674,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -7666,14 +7693,14 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
       "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -7683,7 +7710,7 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
@@ -7696,7 +7723,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
       "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -7715,7 +7742,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -7725,7 +7752,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -7768,7 +7795,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7784,7 +7811,7 @@
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
       "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1"
@@ -7798,7 +7825,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -7931,7 +7958,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -7992,7 +8019,7 @@
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -8101,7 +8128,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8111,7 +8138,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -8124,7 +8151,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -8404,7 +8431,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8414,7 +8441,7 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
       "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "envinfo": "dist/cli.js"
@@ -8427,7 +8454,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -8446,7 +8473,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.2.tgz",
       "integrity": "sha512-kNAL7hESndBCrWwS72QyV3IVOTrVmj9D062FV5BQswNL5zEdeRmz/WJFyh6Aj/plvvSOrzddkxW57HgkZcR9Fw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -9505,7 +9532,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
       "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9521,7 +9548,7 @@
       "version": "5.5.9",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
       "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9651,7 +9678,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -9803,7 +9830,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -10202,38 +10229,6 @@
       "integrity": "sha512-clxa193o+GYYwykWVFfpHduCATz8fR5jvU7ngXpfKHj+E9hr9vjLNtdLSEe8MUbObvVexV3wcyxQ00xTPIrB1Q==",
       "license": "MIT"
     },
-    "node_modules/hermes-eslint": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-eslint/-/hermes-eslint-0.33.3.tgz",
-      "integrity": "sha512-eGY0l6T5U9LDdC+uN88NrSOrvPPtXGPxN7EaD38hytWuBEVXypq0eQ1SNVsnQPBZLWi+b1jkF4F5aVtTCQC6wg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "hermes-estree": "0.33.3",
-        "hermes-parser": "0.33.3"
-      }
-    },
-    "node_modules/hermes-eslint/node_modules/hermes-estree": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
-      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/hermes-eslint/node_modules/hermes-parser": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
-      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.33.3"
-      }
-    },
     "node_modules/hermes-estree": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
@@ -10322,7 +10317,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10339,7 +10334,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10384,7 +10379,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -10512,7 +10507,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -10582,7 +10577,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -10672,7 +10667,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10724,7 +10719,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10926,7 +10921,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10983,7 +10978,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14197,7 +14192,7 @@
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
       "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -14217,7 +14212,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -14255,7 +14250,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -14288,7 +14283,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -14324,7 +14319,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14334,7 +14329,7 @@
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
       "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
@@ -14418,14 +14413,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -14447,7 +14442,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -14467,7 +14462,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -14484,7 +14479,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz",
       "integrity": "sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-fragments": "^0.2.1",
@@ -14499,7 +14494,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -14511,7 +14506,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -14525,7 +14520,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -14538,7 +14533,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -14554,7 +14549,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -14567,7 +14562,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -14582,14 +14577,14 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/logkitty/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
@@ -14612,7 +14607,7 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -14736,7 +14731,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15115,7 +15110,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -15128,7 +15123,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15251,7 +15246,7 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15272,7 +15267,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
       "integrity": "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -15294,7 +15289,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
       "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -15491,7 +15486,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
       "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15525,7 +15520,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
       "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^1.1.0"
@@ -15556,7 +15551,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -15598,7 +15593,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -15614,7 +15609,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -15667,7 +15662,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -15680,7 +15675,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -15724,7 +15719,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
       "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15758,7 +15753,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -16010,7 +16005,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -16212,7 +16207,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -16284,7 +16279,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -16300,7 +16295,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -16321,7 +16316,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -16527,16 +16522,6 @@
       "dependencies": {
         "@freakycoder/react-native-bounceable": "^1.0.3",
         "react-native-bouncy-checkbox": "^4.1.2"
-      }
-    },
-    "node_modules/react-native-camera": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-4.2.1.tgz",
-      "integrity": "sha512-+Vkql24PFYQfsPRznJCvPwJQfyzCnjlcww/iZ4Ej80bgivKjL9eU0IMQIXp4yi6XCrKi4voWXxIDPMupQZKeIQ==",
-      "license": "MIT AND Apache-2.0 AND BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "prop-types": "^15.6.2"
       }
     },
     "node_modules/react-native-contacts": {
@@ -16755,21 +16740,6 @@
       "peerDependencies": {
         "react": "^16.8",
         "react-native": ">=0.59"
-      }
-    },
-    "node_modules/react-native-qrcode-scanner/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-native-qrcode-styled": {
@@ -17203,7 +17173,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -17335,7 +17305,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -17379,7 +17349,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -17389,7 +17359,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -17478,7 +17448,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17533,7 +17503,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -17852,7 +17822,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
@@ -17868,7 +17838,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.0",
@@ -17883,7 +17853,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -17896,7 +17866,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -17906,7 +17876,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/snake-case": {
@@ -18067,14 +18037,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/strict-url-sanitise/-/strict-url-sanitise-0.0.1.tgz",
       "integrity": "sha512-nuFtF539K8jZg3FjaWH/L8eocCR6gegz5RDOsaWxfdbF5Jqr2VXWxZayjTwUzsWJDC91k2EbnJXp6FuWW+Z4hg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -18310,7 +18280,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
       "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18335,7 +18305,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18695,7 +18665,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -18710,7 +18680,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -18805,7 +18775,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -18928,7 +18898,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -19040,7 +19010,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -19071,7 +19041,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -19102,7 +19072,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -19290,7 +19260,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
       "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -19363,7 +19333,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "@shopify/flash-list": "^2.3.1",
+    "@tanstack/react-query": "^5.100.1",
     "axios": "^1.14.0",
     "lottie-react-native": "^7.3.6",
     "react": "^19.2.4",

--- a/screens/home/Home.jsx
+++ b/screens/home/Home.jsx
@@ -1,215 +1,62 @@
-import { useState, useEffect } from 'react'
-import FastImage from '@d11/react-native-fast-image'
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { View, Text, StyleSheet, ScrollView, Pressable, Linking, Platform } from 'react-native'
+import { View, StyleSheet, ScrollView } from 'react-native'
 
 // Auth Context
 import { useAuth } from '../../auth/AuthContext'
 
 // Theme Context
 import { useTheme } from '../../theme/ThemeContext'
-import { useContainerStyles, useTextStyles } from '../../theme/themeUtils'
-
-// APIs
-import { transferApi } from '../../api/transferApi'
-import { userApi } from '../../api/userApi'
-import { blogApi } from '../../api/blogApi'
-import { coinsApi } from '../../api/coinsApi'
-import { promoApi } from '../../api/promoApi'
+import { useContainerStyles } from '../../theme/themeUtils'
 
 // UI Particles
-import QPTransaction from '../../ui/particles/QPTransaction'
 import BalanceCard from '../../ui/BalanceCard'
 import ActionButtons from '../../ui/ActionButtons'
-import QPAvatar from '../../ui/particles/QPAvatar'
-import BlogPostCard from '../../ui/BlogPostCard'
 import QPSectionHeader from '../../ui/particles/QPSectionHeader'
-import WatchlistCard from '../../ui/WatchlistCard'
-import PromoBanner from '../../ui/PromoBanner'
 import CashDeliveryCard from '../../ui/CashDeliveryCard'
-
-// Icons
-import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
 // Routes
 import { ROUTES } from '../../routes'
 
-// Online Status
-import { useOnlineStatus } from '../../hooks/OnlineStatusContext'
-
 // Pull-to-refresh
 import { createHiddenRefreshControl } from '../../ui/QPRefreshIndicator'
-
-// Push prompt
-import usePushPrompt from '../../hooks/usePushPrompt'
 
 // Update prompt
 import UpdatePromptModal from '../../ui/UpdatePromptModal'
 import { maybePromptUpdate } from '../../helpers/versionCheck'
-
-// Service Card Component
-const ServiceCard = ({ icon, title, iconColor, onPress, theme }) => (
-	<Pressable
-		onPress={onPress}
-		style={({ pressed }) => [
-			styles.serviceCard,
-			{
-				backgroundColor: theme.colors.surface,
-				transform: [{ scale: pressed ? 0.97 : 1 }]
-			},
-			theme.mode === 'light' && {
-				borderWidth: 1,
-				borderColor: theme.colors.border,
-			}
-		]}
-	>
-		<View style={[styles.serviceCardIcon, { backgroundColor: iconColor + '20' }]}>
-			<FontAwesome6 name={icon} size={22} color={iconColor} iconStyle="solid" />
-		</View>
-		<Text style={[styles.serviceCardTitle, { color: theme.colors.primaryText, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.medium }]}>{title}</Text>
-	</Pressable>
-)
+import { useHomeProfile } from './hooks/useHomeProfile'
+import HomePromoSection from './_components/HomePromoSection'
+import HomePushBannerSection from './_components/HomePushBannerSection'
+import HomeQuickPaySection from './_components/HomeQuickPaySection'
+import HomeTransactionsSection from './_components/HomeTransactionsSection'
+import HomeWatchlistSection from './_components/HomeWatchlistSection'
+import HomeBlogSection from './_components/HomeBlogSection'
+import HomeServiceCard from './_components/HomeServiceCard'
 
 // Home Screen
 const Home = ({ navigation }) => {
 
 	// User Context
 	const { user, updateUser } = useAuth()
+	const queryClient = useQueryClient()
 
 	// Context
 	const { theme } = useTheme()
 	const containerStyles = useContainerStyles(theme)
-	const textStyles = useTextStyles(theme)
 	const insets = useSafeAreaInsets()
 
-	// Push prompt
-	const { shouldShowBanner, enablePush, dismissBanner } = usePushPrompt()
-
-	// Online status
-	const { trackUsers, untrackUsers, isUserOnline } = useOnlineStatus()
-
 	// State
-	const [, setIsLoading] = useState(false)
 	const [refreshing, setRefreshing] = useState(false)
-	const [latestTransactions, setLatestTransactions] = useState([])
-	const [latestSentTransfersUsers, setLatestSentTransfersUsers] = useState([])
-	const [latestBlogPosts, setLatestBlogPosts] = useState([])
-	const [watchlistData, setWatchlistData] = useState([])
-	const [promo, setPromo] = useState(null)
 	const [updateInfo, setUpdateInfo] = useState(null)
 
-	// Track quick-pay users for online status
-	useEffect(() => {
-		const ids = latestSentTransfersUsers.map(u => u.uuid).filter(Boolean)
-		if (ids.length) trackUsers(ids)
-		return () => { if (ids.length) untrackUsers(ids) }
-	}, [latestSentTransfersUsers, trackUsers, untrackUsers])
-
-	// Load user data
-	useEffect(() => {
-		loadUserData()
-		fetchLatestTransactions()
-		fetchLatestSentTransfersUsers()
-		fetchLatestBlogPosts()
-		fetchWatchlist()
-		fetchPromo()
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [])
-
-	// Load user data from API
-	const loadUserData = async () => {
-		try {
-			setIsLoading(true)
-			const result = await userApi.getUserProfile()
-			if (result.success && result.data) { updateUser(result.data) }
-		} catch (err) { /* error loading user data */ }
-		finally { setIsLoading(false) }
-	}
-
-	const fetchLatestTransactions = async (skipLoading = false) => {
-		try {
-			if (!skipLoading) setIsLoading(true)
-			const result = await transferApi.getLatestTransactions({ take: 6 })
-			if (result.success) {
-				setLatestTransactions(result.data)
-				// Preload avatar images for instant rendering
-				const avatarUrls = result.data
-					.map(t => (t.paid_by_user || t.user)?.image)
-					.filter(Boolean)
-					.map(img => ({ uri: `https://media.qvapay.com/${img}` }))
-				if (avatarUrls.length > 0) FastImage.preload(avatarUrls)
-			}
-		} catch (err) { /* error fetching transactions */ }
-		finally { if (!skipLoading) setIsLoading(false) }
-	}
-
-	const fetchLatestSentTransfersUsers = async (skipLoading = false) => {
-		try {
-			if (!skipLoading) setIsLoading(true)
-			const result = await transferApi.getLatestSentTransfers(10)
-			if (result.success) {
-				// filter out users with no image
-				const users = result.data.filter(u => u.image)
-				setLatestSentTransfersUsers(users)
-			}
-		} catch (err) { /* error fetching sent transfers */ }
-		finally { if (!skipLoading) setIsLoading(false) }
-	}
-
-	const fetchLatestBlogPosts = async (skipLoading = false) => {
-		try {
-			if (!skipLoading) setIsLoading(true)
-			const result = await blogApi.getLatestPosts(Platform.isPad ? 4 : 3)
-			if (result.success) { setLatestBlogPosts(result.data) }
-		} catch (err) { console.error('[Home] blog fetch threw', err) }
-		finally { if (!skipLoading) setIsLoading(false) }
-	}
-
-	const WATCHLIST_COINS = ['BTC', 'ETH', 'LTC', 'SOL']
-
-	const fetchWatchlist = async () => {
-		try {
-			const results = await Promise.all(
-				WATCHLIST_COINS.map(tick => coinsApi.priceHistory(tick, '24H'))
-			)
-			const data = results.map((result, i) => {
-				const tick = WATCHLIST_COINS[i]
-				if (!result.success || !result.data?.length) {
-					return { tick, price: 0, change: 0, priceHistory: [] }
-				}
-				const history = result.data
-				const first = history[0].value
-				const last = history[history.length - 1].value
-				const change = first > 0 ? ((last - first) / first) * 100 : 0
-				return { tick, price: last, change, priceHistory: history }
-			})
-			setWatchlistData(data)
-		} catch { /* error fetching watchlist */ }
-	}
-
-	const fetchPromo = async () => {
-		try {
-			const result = await promoApi.getPromo()
-			if (result.success && result.data) { setPromo(result.data) }
-		} catch { /* no promo available */ }
-	}
+	useHomeProfile(updateUser)
 
 	// Refresh handler for pull-to-refresh
 	const onRefresh = async () => {
 		setRefreshing(true)
 		try {
-			// Refresh user data
-			await loadUserData()
-			// Refresh latest transactions
-			await fetchLatestTransactions(true)
-			// Refresh latest sent transfers users
-			await fetchLatestSentTransfersUsers(true)
-			// Refresh latest blog posts
-			await fetchLatestBlogPosts(true)
-			// Refresh watchlist
-			await fetchWatchlist()
-			// Refresh promo
-			await fetchPromo()
+			await queryClient.refetchQueries({ queryKey: ['home'] })
 			// Check for store update
 			const info = await maybePromptUpdate()
 			if (info?.needsUpdate) setUpdateInfo(info)
@@ -221,67 +68,17 @@ const Home = ({ navigation }) => {
 		<View style={[containerStyles.subContainer]}>
 			<ScrollView style={styles.scrollView} contentContainerStyle={{ paddingBottom: insets.bottom + 20 }} showsVerticalScrollIndicator={false} refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}>
 
-				<PromoBanner promo={promo} />
+				<HomePromoSection />
 
 				<BalanceCard balance={user.balance} navigation={navigation} />
 
 				<ActionButtons navigation={navigation} />
 
-				{shouldShowBanner && (
-					<View style={[styles.pushBanner, { backgroundColor: theme.colors.surface }, theme.mode === 'light' && { borderWidth: 1, borderColor: theme.colors.border }]}>
-						<View style={[styles.pushBannerIcon, { backgroundColor: theme.colors.primary + '20' }]}>
-							<FontAwesome6 name="bell" size={16} color={theme.colors.primary} iconStyle="solid" />
-						</View>
-						<View style={{ flex: 1 }}>
-							<Text style={[styles.pushBannerText, { color: theme.colors.primaryText, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.regular }]}>Recibe alertas de tus pagos al instante</Text>
-						</View>
-						<Pressable
-							onPress={() => { enablePush(); dismissBanner() }}
-							style={[styles.pushBannerButton, { backgroundColor: theme.colors.primary }]}
-						>
-							<Text style={[styles.pushBannerButtonText, { color: theme.colors.almostWhite, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.medium }]}>Activar</Text>
-						</Pressable>
-						<Pressable onPress={dismissBanner} hitSlop={8}>
-							<FontAwesome6 name="xmark" size={14} color={theme.colors.tertiaryText} iconStyle="solid" />
-						</Pressable>
-					</View>
-				)}
+				<HomePushBannerSection />
 
-				<View style={styles.section}>
-					<QPSectionHeader title="Pago rápido" subtitle="Ver todas" iconName="arrow-right" onPress={() => navigation.navigate(ROUTES.SEND)} />
-					<ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingHorizontal: 0 }}>
-						<View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-							<Pressable onPress={() => navigation.navigate(ROUTES.SEND)}>
-								<View style={{ backgroundColor: theme.colors.elevation, height: 56, width: 56, borderRadius: 28, justifyContent: 'center', alignItems: 'center' }}>
-									<FontAwesome6 name="plus" size={24} color={theme.colors.primary} iconStyle="solid" />
-								</View>
-							</Pressable>
-							{latestSentTransfersUsers.map((transferUser, index) => (
-								<Pressable key={index} onPress={() => navigation.navigate(ROUTES.SEND, { user_uuid: transferUser.uuid, send_amount: '0.00' })}>
-									<QPAvatar key={index} user={transferUser} size={56} isOnline={isUserOnline(transferUser.uuid)} />
-								</Pressable>
-							))}
-						</View>
-					</ScrollView>
-				</View>
+				<HomeQuickPaySection />
 
-				<View style={styles.section}>
-					<View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-						<Text style={[textStyles.h5, { color: theme.colors.tertiaryText }]}>Últimas transacciones</Text>
-						<Pressable onPress={() => navigation.navigate(ROUTES.TRANSACTIONS, { showSearch: true })} hitSlop={8}>
-							<FontAwesome6 name="magnifying-glass" size={16} color={theme.colors.tertiaryText} iconStyle="solid" />
-						</Pressable>
-					</View>
-					<View>
-						{latestTransactions.map((transaction, index) => (
-							<QPTransaction key={transaction.uuid} transaction={transaction} navigation={navigation} index={index} totalItems={latestTransactions.length} />
-						))}
-					</View>
-					<Pressable onPress={() => navigation.navigate(ROUTES.TRANSACTIONS)} style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }} >
-						<Text style={{ color: theme.colors.primary, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.medium }}>Ver todas</Text>
-						<FontAwesome6 name="chevron-right" size={12} color={theme.colors.primary} iconStyle="solid" />
-					</Pressable>
-				</View>
+				<HomeTransactionsSection />
 
 				{/* Cash Delivery Card - only show when balance >= 200 */}
 				{Number(user.balance) >= 200 && (<CashDeliveryCard navigation={navigation} />)}
@@ -290,28 +87,28 @@ const Home = ({ navigation }) => {
 				<View style={styles.section}>
 					<QPSectionHeader title="Servicios" subtitle="Ver todas" iconName="arrow-right" onPress={() => navigation.navigate(ROUTES.STORE_SCREEN)} />
 					<View style={styles.serviceCardsContainer}>
-						<ServiceCard
+						<HomeServiceCard
 							icon="mobile-screen"
 							title="Recargas"
 							iconColor="#10B981"
 							onPress={() => navigation.navigate(ROUTES.PHONE_TOPUP_INDEX)}
 							theme={theme}
 						/>
-						<ServiceCard
+						<HomeServiceCard
 							icon="gift"
 							title="Gift Cards"
 							iconColor="#8B5CF6"
 							onPress={() => navigation.navigate(ROUTES.STORE_SCREEN)}
 							theme={theme}
 						/>
-						<ServiceCard
+						<HomeServiceCard
 							icon="chart-line"
 							title="Invest"
 							iconColor="#F59E0B"
 							onPress={() => navigation.navigate(ROUTES.INVEST_SCREEN)}
 							theme={theme}
 						/>
-						<ServiceCard
+						<HomeServiceCard
 							icon="building-columns"
 							title="P2P"
 							iconColor={theme.colors.primary}
@@ -321,25 +118,9 @@ const Home = ({ navigation }) => {
 					</View>
 				</View>
 
-				{watchlistData.length > 0 && (
-					<View style={styles.section}>
-						<QPSectionHeader title="Mi Watchlist" subtitle="Ver todo" iconName="arrow-right" onPress={() => navigation.navigate(ROUTES.INVEST_SCREEN)} />
-						<View style={styles.watchlistGrid}>
-							{watchlistData.map(coin => (
-								<WatchlistCard key={coin.tick} coin={coin} onPress={() => { }} />
-							))}
-						</View>
-					</View>
-				)}
+				<HomeWatchlistSection />
 
-				<View style={styles.section}>
-					<QPSectionHeader title="Últimas noticias" subtitle="Ver todas" iconName="arrow-right" onPress={() => Linking.openURL('https://qvapay.blog')} />
-					<View style={Platform.isPad ? styles.blogGrid : undefined}>
-						{latestBlogPosts.map((post, index) => (
-							<BlogPostCard key={post.id} post={post} index={index} totalItems={latestBlogPosts.length} iPad={Platform.isPad} />
-						))}
-					</View>
-				</View>
+				<HomeBlogSection />
 
 			</ScrollView>
 
@@ -363,60 +144,11 @@ const styles = StyleSheet.create({
 		gap: 8,
 	},
 	// Service Cards
-	watchlistGrid: {
-		flexDirection: 'row',
-		flexWrap: 'wrap',
-		gap: 10,
-	},
 	serviceCardsContainer: {
 		flexDirection: 'row',
 		flexWrap: 'wrap',
 		gap: 10,
 	},
-	serviceCard: {
-		flexBasis: Platform.isPad ? '22%' : '46%',
-		flexGrow: 1,
-		borderRadius: 12,
-		padding: 14,
-		alignItems: 'center',
-		gap: 10,
-	},
-	serviceCardIcon: {
-		width: 48,
-		height: 48,
-		borderRadius: 24,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	serviceCardTitle: {},
-	blogGrid: {
-		flexDirection: 'row',
-		flexWrap: 'wrap',
-		gap: 12,
-	},
-	// Push banner
-	pushBanner: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		borderRadius: 12,
-		padding: 12,
-		marginVertical: 10,
-		gap: 10,
-	},
-	pushBannerIcon: {
-		width: 36,
-		height: 36,
-		borderRadius: 18,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	pushBannerText: {},
-	pushBannerButton: {
-		borderRadius: 8,
-		paddingHorizontal: 12,
-		paddingVertical: 6,
-	},
-	pushBannerButtonText: {},
 })
 
 export default Home

--- a/screens/home/Home.jsx
+++ b/screens/home/Home.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useIsFetching, useQueryClient } from '@tanstack/react-query'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { View, StyleSheet, ScrollView } from 'react-native'
 
@@ -47,21 +47,19 @@ const Home = ({ navigation }) => {
 	const insets = useSafeAreaInsets()
 
 	// State
-	const [refreshing, setRefreshing] = useState(false)
 	const [updateInfo, setUpdateInfo] = useState(null)
+	const refreshing = useIsFetching({ queryKey: ['home'] }) > 0
 
 	useHomeProfile(updateUser)
 
 	// Refresh handler for pull-to-refresh
 	const onRefresh = async () => {
-		setRefreshing(true)
 		try {
 			await queryClient.refetchQueries({ queryKey: ['home'] })
 			// Check for store update
 			const info = await maybePromptUpdate()
 			if (info?.needsUpdate) setUpdateInfo(info)
 		} catch (err) { /* error refreshing data */ }
-		finally { setRefreshing(false) }
 	}
 
 	return (

--- a/screens/home/_components/HomeBlogSection.jsx
+++ b/screens/home/_components/HomeBlogSection.jsx
@@ -1,0 +1,34 @@
+import { Linking, Platform, StyleSheet, View } from 'react-native'
+import QPSectionHeader from '../../../ui/particles/QPSectionHeader'
+import BlogPostCard from '../../../ui/BlogPostCard'
+import { useHomeBlogPosts } from '../hooks/useHomeBlogPosts'
+
+const HomeBlogSection = () => {
+	const { data: latestBlogPosts = [] } = useHomeBlogPosts()
+
+	return (
+		<View style={styles.section}>
+			<QPSectionHeader title="Últimas noticias" subtitle="Ver todas" iconName="arrow-right" onPress={() => Linking.openURL('https://qvapay.blog')} />
+			<View style={Platform.isPad ? styles.blogGrid : undefined}>
+				{latestBlogPosts.map((post, index) => (
+					<BlogPostCard key={post.id} post={post} index={index} totalItems={latestBlogPosts.length} iPad={Platform.isPad} />
+				))}
+			</View>
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	section: {
+		marginVertical: 10,
+		gap: 8,
+	},
+	blogGrid: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		gap: 12,
+	},
+})
+
+export default HomeBlogSection
+

--- a/screens/home/_components/HomePromoSection.jsx
+++ b/screens/home/_components/HomePromoSection.jsx
@@ -1,0 +1,10 @@
+import PromoBanner from '../../../ui/PromoBanner'
+import { useHomePromo } from '../hooks/useHomePromo'
+
+const HomePromoSection = () => {
+	const { data: promo } = useHomePromo()
+	return <PromoBanner promo={promo} />
+}
+
+export default HomePromoSection
+

--- a/screens/home/_components/HomePushBannerSection.jsx
+++ b/screens/home/_components/HomePushBannerSection.jsx
@@ -1,0 +1,59 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
+import { useTheme } from '../../../theme/ThemeContext'
+import usePushPrompt from '../../../hooks/usePushPrompt'
+
+const HomePushBannerSection = () => {
+	const { theme } = useTheme()
+	const { shouldShowBanner, enablePush, dismissBanner } = usePushPrompt()
+
+	if (!shouldShowBanner) return null
+
+	return (
+		<View style={[styles.pushBanner, { backgroundColor: theme.colors.surface }, theme.mode === 'light' && { borderWidth: 1, borderColor: theme.colors.border }]}>
+			<View style={[styles.pushBannerIcon, { backgroundColor: theme.colors.primary + '20' }]}>
+				<FontAwesome6 name="bell" size={16} color={theme.colors.primary} iconStyle="solid" />
+			</View>
+			<View style={{ flex: 1 }}>
+				<Text style={[styles.pushBannerText, { color: theme.colors.primaryText, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.regular }]}>Recibe alertas de tus pagos al instante</Text>
+			</View>
+			<Pressable
+				onPress={() => { enablePush(); dismissBanner() }}
+				style={[styles.pushBannerButton, { backgroundColor: theme.colors.primary }]}
+			>
+				<Text style={[styles.pushBannerButtonText, { color: theme.colors.almostWhite, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.medium }]}>Activar</Text>
+			</Pressable>
+			<Pressable onPress={dismissBanner} hitSlop={8}>
+				<FontAwesome6 name="xmark" size={14} color={theme.colors.tertiaryText} iconStyle="solid" />
+			</Pressable>
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	pushBanner: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		borderRadius: 12,
+		padding: 12,
+		marginVertical: 10,
+		gap: 10,
+	},
+	pushBannerIcon: {
+		width: 36,
+		height: 36,
+		borderRadius: 18,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	pushBannerText: {},
+	pushBannerButton: {
+		borderRadius: 8,
+		paddingHorizontal: 12,
+		paddingVertical: 6,
+	},
+	pushBannerButtonText: {},
+})
+
+export default HomePushBannerSection
+

--- a/screens/home/_components/HomeQuickPaySection.jsx
+++ b/screens/home/_components/HomeQuickPaySection.jsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native'
+import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
+import { useNavigation } from '@react-navigation/native'
+import QPSectionHeader from '../../../ui/particles/QPSectionHeader'
+import QPAvatar from '../../../ui/particles/QPAvatar'
+import { ROUTES } from '../../../routes'
+import { useHomeQuickPayUsers } from '../hooks/useHomeQuickPayUsers'
+import { useOnlineStatus } from '../../../hooks/OnlineStatusContext'
+import { useTheme } from '../../../theme/ThemeContext'
+
+const HomeQuickPaySection = () => {
+	const navigation = useNavigation()
+	const { theme } = useTheme()
+	const { trackUsers, untrackUsers, isUserOnline } = useOnlineStatus()
+	const { data: users = [] } = useHomeQuickPayUsers()
+
+	useEffect(() => {
+		const ids = users.map(u => u.uuid).filter(Boolean)
+		if (ids.length) trackUsers(ids)
+		return () => {
+			if (ids.length) untrackUsers(ids)
+		}
+	}, [users, trackUsers, untrackUsers])
+
+	return (
+		<View style={styles.section}>
+			<QPSectionHeader title="Pago rápido" subtitle="Ver todas" iconName="arrow-right" onPress={() => navigation.navigate(ROUTES.SEND)} />
+			<ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingHorizontal: 0 }}>
+				<View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+					<Pressable onPress={() => navigation.navigate(ROUTES.SEND)}>
+						<View style={{ backgroundColor: theme.colors.elevation, height: 56, width: 56, borderRadius: 28, justifyContent: 'center', alignItems: 'center' }}>
+							<FontAwesome6 name="plus" size={24} color={theme.colors.primary} iconStyle="solid" />
+						</View>
+					</Pressable>
+					{users.map((transferUser) => (
+						<Pressable key={transferUser.uuid} onPress={() => navigation.navigate(ROUTES.SEND, { user_uuid: transferUser.uuid, send_amount: '0.00' })}>
+							<QPAvatar user={transferUser} size={56} isOnline={isUserOnline(transferUser.uuid)} />
+						</Pressable>
+					))}
+				</View>
+			</ScrollView>
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	section: {
+		marginVertical: 10,
+		gap: 8,
+	},
+})
+
+export default HomeQuickPaySection
+

--- a/screens/home/_components/HomeServiceCard.jsx
+++ b/screens/home/_components/HomeServiceCard.jsx
@@ -1,0 +1,58 @@
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
+
+const HomeServiceCard = ({ icon, title, iconColor, onPress, theme }) => (
+	<Pressable
+		onPress={onPress}
+		style={({ pressed }) => [
+			styles.card,
+			{
+				backgroundColor: theme.colors.surface,
+				transform: [{ scale: pressed ? 0.97 : 1 }],
+			},
+			theme.mode === 'light' && styles.cardLight,
+			theme.mode === 'light' && { borderColor: theme.colors.border },
+		]}
+	>
+		<View style={[styles.iconContainer, { backgroundColor: iconColor + '20' }]}>
+			<FontAwesome6 name={icon} size={22} color={iconColor} iconStyle="solid" />
+		</View>
+		<Text
+			style={[
+				styles.title,
+				{
+					color: theme.colors.primaryText,
+					fontSize: theme.typography.fontSize.sm,
+					fontFamily: theme.typography.fontFamily.medium,
+				},
+			]}
+		>
+			{title}
+		</Text>
+	</Pressable>
+)
+
+const styles = StyleSheet.create({
+	card: {
+		flexBasis: Platform.isPad ? '22%' : '46%',
+		flexGrow: 1,
+		borderRadius: 12,
+		padding: 14,
+		alignItems: 'center',
+		gap: 10,
+	},
+	cardLight: {
+		borderWidth: 1,
+	},
+	iconContainer: {
+		width: 48,
+		height: 48,
+		borderRadius: 24,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	title: {},
+})
+
+export default HomeServiceCard
+

--- a/screens/home/_components/HomeTransactionsSection.jsx
+++ b/screens/home/_components/HomeTransactionsSection.jsx
@@ -1,0 +1,48 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
+import { useNavigation } from '@react-navigation/native'
+import { ROUTES } from '../../../routes'
+import QPTransaction from '../../../ui/particles/QPTransaction'
+import { useHomeTransactions } from '../hooks/useHomeTransactions'
+import { useTheme } from '../../../theme/ThemeContext'
+import { useTextStyles } from '../../../theme/themeUtils'
+
+const HomeTransactionsSection = () => {
+	const navigation = useNavigation()
+	const { theme } = useTheme()
+	const textStyles = useTextStyles(theme)
+	const { data: latestTransactions = [], isLoading } = useHomeTransactions()
+
+	return (
+		<View style={styles.section}>
+			<View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+				<Text style={[textStyles.h5, { color: theme.colors.tertiaryText }]}>Últimas transacciones</Text>
+				<Pressable onPress={() => navigation.navigate(ROUTES.TRANSACTIONS, { showSearch: true })} hitSlop={8}>
+					<FontAwesome6 name="magnifying-glass" size={16} color={theme.colors.tertiaryText} iconStyle="solid" />
+				</Pressable>
+			</View>
+			<View>
+				{latestTransactions.map((transaction, index) => (
+					<QPTransaction key={transaction.uuid} transaction={transaction} navigation={navigation} index={index} totalItems={latestTransactions.length} />
+				))}
+				{isLoading && latestTransactions.length === 0 && (
+					<Text style={{ color: theme.colors.tertiaryText, paddingVertical: 8 }}>Cargando transacciones...</Text>
+				)}
+			</View>
+			<Pressable onPress={() => navigation.navigate(ROUTES.TRANSACTIONS)} style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }} >
+				<Text style={{ color: theme.colors.primary, fontSize: theme.typography.fontSize.sm, fontFamily: theme.typography.fontFamily.medium }}>Ver todas</Text>
+				<FontAwesome6 name="chevron-right" size={12} color={theme.colors.primary} iconStyle="solid" />
+			</Pressable>
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	section: {
+		marginVertical: 10,
+		gap: 8,
+	},
+})
+
+export default HomeTransactionsSection
+

--- a/screens/home/_components/HomeWatchlistSection.jsx
+++ b/screens/home/_components/HomeWatchlistSection.jsx
@@ -1,0 +1,39 @@
+import { StyleSheet, View } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { ROUTES } from '../../../routes'
+import QPSectionHeader from '../../../ui/particles/QPSectionHeader'
+import WatchlistCard from '../../../ui/WatchlistCard'
+import { useHomeWatchlist } from '../hooks/useHomeWatchlist'
+
+const HomeWatchlistSection = () => {
+	const navigation = useNavigation()
+	const { data: watchlistData = [] } = useHomeWatchlist()
+
+	if (watchlistData.length === 0) return null
+
+	return (
+		<View style={styles.section}>
+			<QPSectionHeader title="Mi Watchlist" subtitle="Ver todo" iconName="arrow-right" onPress={() => navigation.navigate(ROUTES.INVEST_SCREEN)} />
+			<View style={styles.watchlistGrid}>
+				{watchlistData.map(coin => (
+					<WatchlistCard key={coin.tick} coin={coin} onPress={() => { }} />
+				))}
+			</View>
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	section: {
+		marginVertical: 10,
+		gap: 8,
+	},
+	watchlistGrid: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		gap: 10,
+	},
+})
+
+export default HomeWatchlistSection
+

--- a/screens/home/hooks/useHomeBlogPosts.js
+++ b/screens/home/hooks/useHomeBlogPosts.js
@@ -1,0 +1,22 @@
+import { Platform } from 'react-native'
+import { useQuery } from '@tanstack/react-query'
+import { blogApi } from '../../../api/blogApi'
+
+export const homeBlogPostsQueryKey = (take) => ['home', 'blog', { take }]
+
+export const useHomeBlogPosts = () => {
+	const take = Platform.isPad ? 4 : 3
+
+	return useQuery({
+		queryKey: homeBlogPostsQueryKey(take),
+		queryFn: async () => {
+			const result = await blogApi.getLatestPosts(take)
+			if (!result.success) {
+				throw new Error(result.error || 'No se pudieron cargar las noticias')
+			}
+			return result.data || []
+		},
+		placeholderData: previousData => previousData,
+	})
+}
+

--- a/screens/home/hooks/useHomeProfile.js
+++ b/screens/home/hooks/useHomeProfile.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { userApi } from '../../../api/userApi'
+
+export const homeProfileQueryKey = ['home', 'profile']
+
+export const useHomeProfile = (updateUser) => useQuery({
+	queryKey: homeProfileQueryKey,
+	queryFn: async () => {
+		const result = await userApi.getUserProfile()
+		if (!result.success || !result.data) {
+			throw new Error(result.error || 'No se pudo cargar el perfil')
+		}
+		updateUser(result.data)
+		return result.data
+	},
+	staleTime: 60000,
+})
+

--- a/screens/home/hooks/useHomePromo.js
+++ b/screens/home/hooks/useHomePromo.js
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import promoApi from '../../../api/promoApi'
+
+export const homePromoQueryKey = ['home', 'promo']
+
+export const useHomePromo = () => useQuery({
+	queryKey: homePromoQueryKey,
+	queryFn: async () => {
+		const result = await promoApi.getPromo()
+		if (!result.success) {
+			return null
+		}
+		return result.data || null
+	},
+	placeholderData: previousData => previousData,
+})
+

--- a/screens/home/hooks/useHomeQuickPayUsers.js
+++ b/screens/home/hooks/useHomeQuickPayUsers.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { transferApi } from '../../../api/transferApi'
+
+const DEFAULT_TAKE = 10
+
+export const homeQuickPayUsersQueryKey = (take = DEFAULT_TAKE) => ['home', 'quick-pay-users', { take }]
+
+export const useHomeQuickPayUsers = (take = DEFAULT_TAKE) => useQuery({
+	queryKey: homeQuickPayUsersQueryKey(take),
+	queryFn: async () => {
+		const result = await transferApi.getLatestSentTransfers(take)
+		if (!result.success) {
+			throw new Error(result.error || 'No se pudieron cargar los usuarios recientes')
+		}
+		return (result.data || []).filter(user => user.image)
+	},
+	placeholderData: previousData => previousData,
+})
+

--- a/screens/home/hooks/useHomeTransactions.js
+++ b/screens/home/hooks/useHomeTransactions.js
@@ -1,0 +1,31 @@
+import FastImage from '@d11/react-native-fast-image'
+import { useQuery } from '@tanstack/react-query'
+import { transferApi } from '../../../api/transferApi'
+
+const DEFAULT_TAKE = 6
+
+export const homeTransactionsQueryKey = (take = DEFAULT_TAKE) => ['home', 'transactions', { take }]
+
+export const useHomeTransactions = (take = DEFAULT_TAKE) => useQuery({
+	queryKey: homeTransactionsQueryKey(take),
+	queryFn: async () => {
+		const result = await transferApi.getLatestTransactions({ take })
+		if (!result.success) {
+			throw new Error(result.error || 'No se pudieron cargar las transacciones')
+		}
+
+		const transactions = result.data || []
+		const avatarUrls = transactions
+			.map(t => (t.paid_by_user || t.user)?.image)
+			.filter(Boolean)
+			.map(image => ({ uri: `https://media.qvapay.com/${image}` }))
+
+		if (avatarUrls.length) {
+			FastImage.preload(avatarUrls)
+		}
+
+		return transactions
+	},
+	placeholderData: previousData => previousData,
+})
+

--- a/screens/home/hooks/useHomeWatchlist.js
+++ b/screens/home/hooks/useHomeWatchlist.js
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+import { coinsApi } from '../../../api/coinsApi'
+
+const WATCHLIST_COINS = ['BTC', 'ETH', 'LTC', 'SOL']
+
+export const homeWatchlistQueryKey = ['home', 'watchlist', '24H']
+
+export const useHomeWatchlist = () => useQuery({
+	queryKey: homeWatchlistQueryKey,
+	queryFn: async () => {
+		const results = await Promise.all(
+			WATCHLIST_COINS.map(tick => coinsApi.priceHistory(tick, '24H'))
+		)
+
+		return results.map((result, index) => {
+			const tick = WATCHLIST_COINS[index]
+			if (!result.success || !result.data?.length) {
+				return { tick, price: 0, change: 0, priceHistory: [] }
+			}
+
+			const history = result.data
+			const first = history[0].value
+			const last = history[history.length - 1].value
+			const change = first > 0 ? ((last - first) / first) * 100 : 0
+
+			return {
+				tick,
+				price: last,
+				change,
+				priceHistory: history,
+			}
+		})
+	},
+	placeholderData: previousData => previousData,
+})
+


### PR DESCRIPTION
**Summary**
- Migrates Home data loading from imperative `useEffect` + local state to TanStack React Query.
- Splits Home sections into local `_components` and moves each section’s data/loading logic into dedicated hooks.
- Simplifies `Home.jsx` into a composition shell and updates pull-to-refresh to use query refetching.

**Scope**
- React Query provider setup in app root.
- New hooks under `screens/home/hooks`.
- New section components under `screens/home/_components`.
- Service card extracted into `HomeServiceCard`.
- Refresh behavior switched to `queryClient.refetchQueries({ queryKey: ['home'] })`.

**Key files**
- `App.tsx`
- `screens/home/Home.jsx`
- `screens/home/hooks/*`
- `screens/home/_components/*`

**Behavioral impact**
- No intended UX changes; architecture and data flow refactor only.
- Home sections now fetch/render independently and are easier to maintain.

**Test plan**
- Launch app and open Home.
- Verify sections load correctly:
  - Promo banner
  - Quick pay users
  - Latest transactions
  - Watchlist
  - Blog posts
- Pull to refresh Home and confirm data refetches.
- Verify push banner actions still work.
- Verify navigation from each section still works.
- Run lint on touched files.
