### PR TITLE
Bind Gold IAP purchase to QvaPay user (obfuscatedAccountId / appAccountToken)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
 	"name": "QvaPay",
 	"displayName": "QvaPay",
-	"version": "1.6.1",
-	"versionCode": 1601
+	"version": "1.6.2",
+	"versionCode": 1602
 }

--- a/screens/settings/subpanels/GoldCheck.jsx
+++ b/screens/settings/subpanels/GoldCheck.jsx
@@ -205,13 +205,17 @@ const GoldCheck = ({ navigation }) => {
         setIsPurchasingIAP(true)
 
         try {
+            // Bind the purchase to the QvaPay user so RTDN events can map back to the right account
+            // when the IAPTransaction row doesn't exist yet (race between client validate and Google's webhook).
+            const accountId = user?.uuid
             const purchaseRequest = {
                 type: 'subs',
                 request: Platform.OS === 'ios'
-                    ? { apple: { sku: productId } }
+                    ? { apple: { sku: productId, ...(accountId && { appAccountToken: accountId }) } }
                     : {
                         google: {
                             skus: [productId],
+                            ...(accountId && { obfuscatedAccountId: accountId }),
                             ...(offerToken && {
                                 subscriptionOffers: [{ sku: productId, offerToken }],
                             }),
@@ -224,7 +228,7 @@ const GoldCheck = ({ navigation }) => {
             const message = getIAPErrorMessage(error)
             if (message) toast.error(message)
         }
-    }, [selectedPlan, subscriptions, requestPurchase])
+    }, [selectedPlan, subscriptions, requestPurchase, user?.uuid])
 
     // Handle Restore Purchases
     const handleRestore = useCallback(async () => {


### PR DESCRIPTION
## Summary

When the user starts a Gold subscription purchase, we never attached a stable identifier that ties the purchase back to their QvaPay account. The backend RTDN handler has two ways to map an incoming Google Play notification to a user:

1. Look up an existing `IAPTransaction` row by purchase token — only exists if the client already called `/validate-receipt` successfully.
2. Read `subscription.externalAccountIdentifiers.obfuscatedExternalAccountId` from the Google response — only populated if the app set it at purchase time.

Path 1 races against the webhook (closing the app mid-purchase or a slow network ⇒ Google's RTDN arrives first ⇒ no row yet). Path 2 has been dead code because we weren't passing the binding.

This PR sets `obfuscatedAccountId: user.uuid` on Android and `appAccountToken: user.uuid` on iOS in the `requestPurchase` call. Both fields are echoed back by the stores in every subsequent server notification, so the backend fallback can finally find the user.

## Test plan

- [ ] Trigger a test purchase from Play Console internal testing track
- [ ] Confirm the RTDN PURCHASED event in backend logs includes `externalAccountIdentifiers.obfuscatedExternalAccountId == <user.uuid>`
- [ ] Sign out of the app right after initiating purchase, sign back in → Gold should activate when Google's webhook lands

## Companion backend PR

[n3omaster/qpweb#14](https://github.com/n3omaster/qpweb/pull/14) — hardens the RTDN endpoint, fixes the yearly-mapping bug, and prevents double-extension of `golden_expire`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)