### PR TITLE
Subir la gema json a 2.21.2 (GHSA-9hj4-r449-hfvc)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       mutex_m
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    json (2.20.0)
+    json (2.21.2)
     logger (1.7.0)
     minitest (5.27.0)
     molinillo (0.8.0)


### PR DESCRIPTION
Dependabot marca `json` 2.20.0 por un uso de memoria liberada en `JSON::ResumableParser#partial_value` al procesar streams truncados con claves duplicadas. Severidad baja y alcance limitado: la gema entra por CocoaPods, así que solo se ejecuta en la máquina de desarrollo y en CI durante `pod install` — nunca viaja en la app.

Aun así hay parche publicado y el salto es de patch, así que no hay motivo para quedarse atrás. `bundle install` resuelve limpio y CocoaPods sigue en 1.16.2, la versión con la que se generó ios/Podfile.lock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single patch-version lockfile bump for a dev/CI-only Ruby dependency; no application runtime or auth/data-path changes.
> 
> **Overview**
> Bumps the locked **`json`** gem from **2.20.0** to **2.21.2** in `Gemfile.lock` to address **GHSA-9hj4-r449-hfvc** (use-after-free in `JSON::ResumableParser#partial_value` on truncated streams with duplicate keys).
> 
> `json` is pulled in transitively for the iOS toolchain (e.g. via CocoaPods / `algoliasearch`), not as a direct app runtime dependency—so the change affects **local dev and CI** during `bundle install` / `pod install`, not shipped mobile binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09697789dd240eb0f2a7ddd7384cd2b06037f805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->