### PR TITLE
Memoizar el contentContainerStyle con inset en 18 pantallas

### DIFF
--- a/hooks/useContentPadding.js
+++ b/hooks/useContentPadding.js
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+/**
+ * Estilo memoizado para el `contentContainerStyle` de una lista o un ScrollView,
+ * con el hueco inferior del área segura ya sumado.
+ *
+ * Escrito a mano, `contentContainerStyle={{ paddingBottom: insets.bottom + 30 }}`
+ * crea un objeto nuevo en cada render. El contenedor de contenido recibe
+ * entonces un `style` con identidad distinta aunque los valores sean idénticos,
+ * lo que obliga a reconciliar y volver a diferenciar el estilo; en FlashList,
+ * además, un cambio de `contentContainerStyle` puede provocar un nuevo cálculo
+ * de layout de la lista. Memoizando contra `insets.bottom` el objeto solo cambia
+ * cuando cambia de verdad (rotación, barra de gestos).
+ *
+ * De paso centraliza la aritmética: había dieciocho copias del mismo
+ * `insets.bottom + N` repartidas por las pantallas.
+ *
+ * @param {number} [extraBottom=0] - Margen inferior propio de la pantalla, que se suma al inset.
+ * @param {number} [top] - `paddingTop` opcional; se omite del estilo si no se pasa.
+ * @returns {{ paddingBottom: number, paddingTop?: number }} Estilo estable entre renders.
+ *
+ * @example
+ * const contentPadding = useContentPadding(30)
+ * return <ScrollView contentContainerStyle={contentPadding}>…</ScrollView>
+ */
+export default function useContentPadding(extraBottom = 0, top) {
+
+	const insets = useSafeAreaInsets()
+
+	return useMemo(() => {
+		const style = { paddingBottom: insets.bottom + extraBottom }
+		if (top != null) { style.paddingTop = top }
+		return style
+	}, [insets.bottom, extraBottom, top])
+}

--- a/hooks/useContentPadding.test.js
+++ b/hooks/useContentPadding.test.js
@@ -1,0 +1,72 @@
+/**
+ * Tests del estilo memoizado de `contentContainerStyle`.
+ *
+ * Lo que se fija aquí no son los números, sino la IDENTIDAD del objeto: el
+ * motivo de existir del hook es que el estilo no cambie de referencia en cada
+ * render. Un test que solo comprobara los valores pasaría igual con la versión
+ * anterior, que creaba un objeto nuevo cada vez.
+ * @jest-environment node
+ */
+let mockInsets = { top: 0, bottom: 34, left: 0, right: 0 }
+jest.mock('react-native-safe-area-context', () => ({
+	useSafeAreaInsets: () => mockInsets,
+}))
+
+import React from 'react'
+import { act, create } from 'react-test-renderer'
+import useContentPadding from './useContentPadding'
+
+const renderHook = (...args) => {
+	const result = { current: null, renders: 0 }
+	const Harness = () => {
+		result.current = useContentPadding(...args)
+		result.renders++
+		return null
+	}
+	let tree
+	act(() => { tree = create(<Harness />) })
+	result.rerender = () => act(() => { tree.update(<Harness />) })
+	return result
+}
+
+beforeEach(() => { mockInsets = { top: 0, bottom: 34, left: 0, right: 0 } })
+
+describe('valores', () => {
+	test('suma el inset inferior al margen propio de la pantalla', () => {
+		expect(renderHook(30).current).toEqual({ paddingBottom: 64 })
+	})
+
+	test('sin argumentos devuelve solo el inset', () => {
+		expect(renderHook().current).toEqual({ paddingBottom: 34 })
+	})
+
+	test('el paddingTop solo aparece si se pide', () => {
+		expect(renderHook(30).current.paddingTop).toBeUndefined()
+		expect(renderHook(30, 8).current).toEqual({ paddingBottom: 64, paddingTop: 8 })
+	})
+
+	test('un inset de 0 (Android sin barra de gestos) no rompe la suma', () => {
+		mockInsets = { top: 0, bottom: 0, left: 0, right: 0 }
+		expect(renderHook(24).current).toEqual({ paddingBottom: 24 })
+	})
+})
+
+describe('estabilidad', () => {
+	test('devuelve EL MISMO objeto mientras el inset no cambie', () => {
+		const hook = renderHook(30)
+		const first = hook.current
+		hook.rerender()
+		hook.rerender()
+		expect(hook.renders).toBeGreaterThan(1)
+		expect(hook.current).toBe(first) // identidad, no igualdad
+	})
+
+	test('devuelve un objeto nuevo cuando cambia el inset (rotación)', () => {
+		const hook = renderHook(30)
+		const first = hook.current
+		mockInsets = { top: 0, bottom: 0, left: 0, right: 0 }
+		hook.rerender()
+		expect(hook.current).not.toBe(first)
+		expect(hook.current).toEqual({ paddingBottom: 30 })
+	})
+})

--- a/screens/home/Home.jsx
+++ b/screens/home/Home.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useSharedValue } from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 import { View, Text, StyleSheet, ScrollView, Pressable, Linking, Platform } from 'react-native'
 
 // Auth Context
@@ -135,7 +135,7 @@ const Home = ({ navigation }) => {
 	const { theme } = useTheme()
 	const containerStyles = useContainerStyles(theme)
 	const textStyles = useTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(20)
 
 	// Online status
 	const { trackUsers, untrackUsers, isUserOnline } = useOnlineStatus()
@@ -173,7 +173,7 @@ const Home = ({ navigation }) => {
 
 	return (
 		<View style={[containerStyles.subContainer]}>
-			<ScrollView style={styles.scrollView} contentContainerStyle={{ paddingBottom: insets.bottom + 20 }} showsVerticalScrollIndicator={false} refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}>
+			<ScrollView style={styles.scrollView} contentContainerStyle={contentPadding} showsVerticalScrollIndicator={false} refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}>
 
 				<PromoBanner promo={promo} />
 

--- a/screens/p2p/P2P.jsx
+++ b/screens/p2p/P2P.jsx
@@ -1,5 +1,5 @@
 import { FlashList } from "@shopify/flash-list"
-import { useEffect, useReducer, useCallback, useRef } from "react"
+import { useEffect, useReducer, useCallback, useMemo, useRef } from "react"
 import { View, Text, StyleSheet, Pressable, Platform, useWindowDimensions, ActivityIndicator } from "react-native"
 
 // Reanimated
@@ -80,6 +80,13 @@ const P2P = ({ navigation, route }) => {
 	const containerStyles = useContainerStyles(theme)
 	const insets = useSafeAreaInsets()
 	const { height: windowHeight, width: windowWidth } = useWindowDimensions()
+
+	// No usa useContentPadding porque Android no suma el inset: ahí la barra
+	// inferior propia ya cubre esa zona y sumarlo dejaba un hueco doble
+	const contentPadding = useMemo(
+		() => ({ paddingBottom: Platform.OS === 'ios' ? 64 + insets.bottom : 24 }),
+		[insets.bottom]
+	)
 
 	// Ancho del switch del header: lo más generoso que quepa sin acercarse al
 	// avatar ni a los botones (reservamos ~190px para ellos), con tope para que
@@ -303,7 +310,7 @@ const P2P = ({ navigation, route }) => {
 				scrollEventThrottle={16}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 				showsVerticalScrollIndicator={false}
-				contentContainerStyle={{ paddingBottom: Platform.OS === 'ios' ? 64 + insets.bottom : 24 }}
+				contentContainerStyle={contentPadding}
 				onEndReached={handleLoadMore}
 				onEndReachedThreshold={0.3}
 				ListFooterComponent={renderFooter}

--- a/screens/store/GiftCardBrand.jsx
+++ b/screens/store/GiftCardBrand.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useLayoutEffect, useCallback, useReducer } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, TextInput, Platform } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 
 // Toast
 import { toast } from 'sonner-native'
@@ -137,7 +137,7 @@ const GiftCardBrand = ({ navigation, route }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding()
 
 	const [data, dispatchData] = useReducer(dataReducer, { country: initCountry || null, brand: '', brandLogo: null, offers: [] })
 	const { country, brand, brandLogo, offers } = data
@@ -267,7 +267,7 @@ const GiftCardBrand = ({ navigation, route }) => {
 
 	return (
 		<View style={containerStyles.subContainer}>
-			<ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: insets.bottom }}>
+			<ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={contentPadding}>
 
 				<View style={styles.header}>
 					<OperatorAvatar brand={brand} logoUrl={brandLogo} size="lg" />

--- a/screens/store/GiftCards.jsx
+++ b/screens/store/GiftCards.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useReducer } from 'react'
 import { View, Text, StyleSheet, ScrollView, useWindowDimensions } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 import { FlashList } from '@shopify/flash-list'
 
 import { useTheme } from '../../theme/ThemeContext'
@@ -54,7 +54,7 @@ const GiftCards = ({ navigation, route }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(24)
 	const { width } = useWindowDimensions()
 	const numColumns = width >= 1024 ? 4 : width >= 600 ? 3 : 2
 
@@ -154,7 +154,7 @@ const GiftCards = ({ navigation, route }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 			>

--- a/screens/store/PhoneTopupBrand.jsx
+++ b/screens/store/PhoneTopupBrand.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useLayoutEffect, useCallback, useReducer } from 'react'
 import { View, Text, StyleSheet, ScrollView, Platform } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 import { toast } from 'sonner-native'
 
@@ -47,7 +47,7 @@ const PhoneTopupBrand = ({ navigation, route }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding()
 	const isGold = user?.golden_check
 
 	// Fetched brand data (same-named setters keep every call site unchanged)
@@ -219,7 +219,7 @@ const PhoneTopupBrand = ({ navigation, route }) => {
 
 	return (
 		<View style={containerStyles.subContainer}>
-			<ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: insets.bottom }}>
+			<ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={contentPadding}>
 
 				{/* Header */}
 				<View style={styles.header}>

--- a/screens/store/PhoneTopupIndex.jsx
+++ b/screens/store/PhoneTopupIndex.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useReducer } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, useWindowDimensions } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 import { FlashList } from '@shopify/flash-list'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
@@ -59,7 +59,7 @@ const PhoneTopupIndex = ({ navigation, route }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(24)
 	const { width } = useWindowDimensions()
 	const numColumns = width >= 768 ? 3 : 2
 
@@ -164,7 +164,7 @@ const PhoneTopupIndex = ({ navigation, route }) => {
 		<View style={containerStyles.subContainer}>
 			<ScrollView
 				style={styles.scrollView}
-				contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 			>

--- a/screens/store/Store.jsx
+++ b/screens/store/Store.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useReducer } from 'react'
 import { View, Text, StyleSheet, ScrollView, Platform, Pressable, useWindowDimensions } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
 // Toast
@@ -59,7 +59,7 @@ const Store = ({ navigation }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30)
 	const { width } = useWindowDimensions()
 	const numColumns = width >= 1024 ? 4 : width >= 600 ? 3 : 2
 
@@ -163,7 +163,7 @@ const Store = ({ navigation }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 30 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 			>

--- a/screens/store/assisted/AssistedCart.jsx
+++ b/screens/store/assisted/AssistedCart.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FastImage from '@d11/react-native-fast-image'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
@@ -32,7 +32,7 @@ const AssistedCart = ({ navigation }) => {
 	const { theme, styles: themeStyles } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30, 8)
 
 	const [cart, setCart] = useState(null)
 	const [refreshing, setRefreshing] = useState(false)
@@ -109,7 +109,7 @@ const AssistedCart = ({ navigation }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 30, paddingTop: 8 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 			>

--- a/screens/store/assisted/AssistedCheckout.jsx
+++ b/screens/store/assisted/AssistedCheckout.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, Modal } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
 // Toast
@@ -98,7 +98,7 @@ const AssistedCheckout = ({ navigation }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30, 8)
 
 	const [addresses, setAddresses] = useState([])
 	const [loading, setLoading] = useState(true)
@@ -198,7 +198,7 @@ const AssistedCheckout = ({ navigation }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 30, paddingTop: 8 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				keyboardShouldPersistTaps="handled"
 			>

--- a/screens/store/assisted/AssistedOrderDetail.jsx
+++ b/screens/store/assisted/AssistedOrderDetail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { View, Text, StyleSheet, ScrollView } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FastImage from '@d11/react-native-fast-image'
 
 // Toast
@@ -31,7 +31,7 @@ const AssistedOrderDetail = ({ route }) => {
 	const { theme, styles: themeStyles } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30, 8)
 
 	const [order, setOrder] = useState(null)
 	const [refreshing, setRefreshing] = useState(false)
@@ -62,7 +62,7 @@ const AssistedOrderDetail = ({ route }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 30, paddingTop: 8 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 			>

--- a/screens/store/assisted/AssistedProduct.jsx
+++ b/screens/store/assisted/AssistedProduct.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, Linking } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FastImage from '@d11/react-native-fast-image'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
@@ -34,7 +34,7 @@ const AssistedProduct = ({ navigation, route }) => {
 	const { theme, styles: themeStyles } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30)
 
 	const [product, setProduct] = useState(route.params?.product || null)
 	const [quantity, setQuantity] = useState(1)
@@ -84,7 +84,7 @@ const AssistedProduct = ({ navigation, route }) => {
 
 	return (
 		<View style={containerStyles.subContainer}>
-			<ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 30 }} showsVerticalScrollIndicator={false}>
+			<ScrollView contentContainerStyle={contentPadding} showsVerticalScrollIndicator={false}>
 
 				{/* Gallery */}
 				<View style={styles.mainImageWrap}>

--- a/screens/store/assisted/AssistedShopping.jsx
+++ b/screens/store/assisted/AssistedShopping.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, useWindowDimensions } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FastImage from '@d11/react-native-fast-image'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
@@ -34,7 +34,7 @@ const AssistedShopping = ({ navigation }) => {
 	const { theme, styles: themeStyles } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30)
 	const { width } = useWindowDimensions()
 	const numColumns = width >= 600 ? 3 : 2
 
@@ -88,7 +88,7 @@ const AssistedShopping = ({ navigation }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 30 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 				keyboardShouldPersistTaps="handled"

--- a/screens/store/market/MarketCart.jsx
+++ b/screens/store/market/MarketCart.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useReducer, useRef } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, Modal } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 import FastImage from '@d11/react-native-fast-image'
 
@@ -92,7 +92,7 @@ const MarketCart = ({ navigation }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30, 8)
 
 	const { items, remove, setQty, clear } = useMarketCart()
 
@@ -294,7 +294,7 @@ const MarketCart = ({ navigation }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 30, paddingTop: 8 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				keyboardShouldPersistTaps="handled"
 			>

--- a/screens/store/market/MarketOrderDetail.jsx
+++ b/screens/store/market/MarketOrderDetail.jsx
@@ -1,5 +1,5 @@
 import { View, Text, StyleSheet, ScrollView, Pressable } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import Clipboard from '@react-native-clipboard/clipboard'
 import FastImage from '@d11/react-native-fast-image'
 
@@ -41,7 +41,7 @@ const MarketOrderDetail = ({ navigation, route }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30, 8)
 
 	if (!order) return <View style={containerStyles.subContainer} />
 
@@ -58,7 +58,7 @@ const MarketOrderDetail = ({ navigation, route }) => {
 
 	return (
 		<View style={containerStyles.subContainer}>
-			<ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 30, paddingTop: 8 }} showsVerticalScrollIndicator={false}>
+			<ScrollView contentContainerStyle={contentPadding} showsVerticalScrollIndicator={false}>
 
 				{/* Producto */}
 				<View style={[styles.card, { backgroundColor: theme.colors.surface }, theme.mode === 'light' && { borderWidth: 0.5, borderColor: theme.colors.border }]}>

--- a/screens/store/market/MarketProduct.jsx
+++ b/screens/store/market/MarketProduct.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, useWindowDimensions } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import FastImage from '@d11/react-native-fast-image'
 
 import { useTheme } from '../../../theme/ThemeContext'
@@ -133,6 +134,7 @@ const MarketProduct = ({ navigation, route }) => {
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
 	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(110)
 	const { width } = useWindowDimensions()
 	const galleryWidth = width - 40 // subContainer padding
 
@@ -237,7 +239,7 @@ const MarketProduct = ({ navigation, route }) => {
 
 	return (
 		<View style={containerStyles.subContainer}>
-			<ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 110 }} showsVerticalScrollIndicator={false}>
+			<ScrollView contentContainerStyle={contentPadding} showsVerticalScrollIndicator={false}>
 
 				{/* Galería */}
 				<View style={[styles.gallery, { backgroundColor: theme.colors.elevationLight }]}>

--- a/screens/store/market/MarketStore.jsx
+++ b/screens/store/market/MarketStore.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useReducer, useRef } from 'react'
 import { View, Text, StyleSheet, ScrollView, Pressable, Linking, Share, useWindowDimensions } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import { FlashList } from '@shopify/flash-list'
 import FastImage from '@d11/react-native-fast-image'
 import LinearGradient from 'react-native-linear-gradient'
@@ -83,6 +84,7 @@ const MarketStore = ({ navigation, route }) => {
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
 	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(24)
 	const { width, height: windowHeight } = useWindowDimensions()
 	const numColumns = width >= 1024 ? 4 : width >= 600 ? 3 : 2
 	const { count: cartCount } = useMarketCart()
@@ -201,7 +203,7 @@ const MarketStore = ({ navigation, route }) => {
 	return (
 		<View style={containerStyles.container}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				contentInsetAdjustmentBehavior="never"
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}

--- a/screens/store/market/MarketStores.jsx
+++ b/screens/store/market/MarketStores.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useReducer, useRef } from 'react'
 import { View, Text, StyleSheet, ScrollView, useWindowDimensions } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../../hooks/useContentPadding'
 import { FlashList } from '@shopify/flash-list'
 
 import { useTheme } from '../../../theme/ThemeContext'
@@ -50,7 +50,7 @@ const MarketStores = ({ navigation, route }) => {
 	const { theme } = useTheme()
 	const containerStyles = createContainerStyles(theme)
 	const textStyles = createTextStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(24)
 	const { width } = useWindowDimensions()
 	const numColumns = width >= 1024 ? 4 : width >= 600 ? 3 : 2
 
@@ -154,7 +154,7 @@ const MarketStores = ({ navigation, route }) => {
 	return (
 		<View style={containerStyles.subContainer}>
 			<ScrollView
-				contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+				contentContainerStyle={contentPadding}
 				showsVerticalScrollIndicator={false}
 				refreshControl={createHiddenRefreshControl(refreshing, onRefresh)}
 			>

--- a/screens/topup/TopupScreen.jsx
+++ b/screens/topup/TopupScreen.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { View, Text, ScrollView, Platform, StyleSheet } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import useContentPadding from '../../hooks/useContentPadding'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { toast } from 'sonner-native'
 
@@ -49,7 +49,7 @@ const TopupScreen = () => {
 	const { theme } = useTheme()
 	const textStyles = createTextStyles(theme)
 	const containerStyles = createContainerStyles(theme)
-	const insets = useSafeAreaInsets()
+	const contentPadding = useContentPadding(30)
 
 	const [phoneNumber, setPhoneNumber] = useState('')
 	const [selectedSku, setSelectedSku] = useState(TOPUP_SKUS?.[0] || null)
@@ -249,7 +249,7 @@ const TopupScreen = () => {
 	return (
 		<ScrollView
 			style={[containerStyles.container, { paddingHorizontal: theme.spacing.md }]}
-			contentContainerStyle={{ paddingBottom: insets.bottom + 30 }}
+			contentContainerStyle={contentPadding}
 			showsVerticalScrollIndicator={false}
 			keyboardShouldPersistTaps="handled"
 		>


### PR DESCRIPTION
## Qué

`contentContainerStyle={{ paddingBottom: insets.bottom + 30 }}` crea un objeto nuevo en cada render: el contenedor de contenido recibe un `style` con identidad distinta aunque los valores sean idénticos, hay que reconciliar y volver a diferenciar el estilo, y en FlashList un cambio de `contentContainerStyle` puede disparar un recálculo de layout de la lista.

Se centraliza en `hooks/useContentPadding.js`, que encapsula `useSafeAreaInsets` y memoiza contra `insets.bottom`. De paso desaparecen 18 copias del mismo `insets.bottom + N`, y el import de safe-area sobra en 16 de las 18 pantallas.

Cierra la regla `react-doctor/rn-scrollview-dynamic-padding` (18 → 0).

## Excepciones deliberadas

- **MarketProduct** y **MarketStore** conservan `insets`: lo usan también para otras cosas.
- **P2P** se queda con un `useMemo` local. Su padding es `Platform.OS === 'ios' ? 64 + insets.bottom : 24` y en Android **no suma el inset a propósito** (la barra inferior propia ya cubre esa zona). Meterlo en el hook habría cambiado el layout en Android.

## Riesgo

**Sin cambios visuales**: los valores resultantes son idénticos. Un fallo aquí se vería como el último elemento tapado por la barra, o un hueco de más al final del scroll.

## Verificación

- 1465 tests / 130 suites en verde; lint con 0 errores.
- El test de estabilidad del hook comprueba la **identidad** del objeto, no los valores. Verificado que falla si se quita el `useMemo` — un test de valores habría pasado igual con el código anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: padding values stay the same; main risk is a wrong bottom inset on a screen (content clipped or extra gap), mitigated by tests and deliberate P2P Android exception.
> 
> **Overview**
> Adds **`useContentPadding`**, a hook that builds a stable `contentContainerStyle` from the bottom safe-area inset plus an optional extra bottom margin and optional `paddingTop`. It replaces inline `{{ paddingBottom: insets.bottom + N }}` on many **ScrollView** / **FlashList** screens so the style object does not change reference every render (fewer style reconciliations and less **FlashList** layout churn).
> 
> Most home, store, assisted-shopping, market, and top-up screens now pass that memoized style instead of calling **`useSafeAreaInsets`** locally for scroll padding. **`P2P`** keeps a local **`useMemo`** with iOS-only inset math so Android does not double-count the custom bottom bar. Tests assert **object identity** across rerenders, not just numeric padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523fa0b0723ba7a2155053ceeefcac66342cbfb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->