### PR TITLE
Release 2.3.5 (versionCode 2305)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
 	"name": "QvaPay",
 	"displayName": "QvaPay",
-	"version": "2.3.4",
-	"versionCode": 2304
+	"version": "2.3.5",
+	"versionCode": 2305
 }

--- a/ios/QvaPay.xcodeproj/project.pbxproj
+++ b/ios/QvaPay.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPay/QvaPay.entitlements;
-				CURRENT_PROJECT_VERSION = 2304;
+				CURRENT_PROJECT_VERSION = 2305;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				ENABLE_BITCODE = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -472,7 +472,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.4;
+				MARKETING_VERSION = 2.3.5;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -497,7 +497,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPay/QvaPay.entitlements;
-				CURRENT_PROJECT_VERSION = 2304;
+				CURRENT_PROJECT_VERSION = 2305;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = QvaPay/Info.plist;
@@ -508,7 +508,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.4;
+				MARKETING_VERSION = 2.3.5;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -750,7 +750,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPayWidgets/QvaPayWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2304;
+				CURRENT_PROJECT_VERSION = 2305;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = QvaPayWidgets/Info.plist;
@@ -762,7 +762,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.4;
+				MARKETING_VERSION = 2.3.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.qvapay.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -781,7 +781,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPayWidgets/QvaPayWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2304;
+				CURRENT_PROJECT_VERSION = 2305;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = QvaPayWidgets/Info.plist;
@@ -793,7 +793,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.4;
+				MARKETING_VERSION = 2.3.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.qvapay.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "QvaPay",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Bump de versión para el release de la tanda de pulido del P2P y el selector de monedas.

| | antes | después |
|---|---|---|
| `app.json` version | 2.3.4 | **2.3.5** |
| `app.json` versionCode | 2304 | **2305** |
| iOS `MARKETING_VERSION` | 2.3.4 | **2.3.5** |
| iOS `CURRENT_PROJECT_VERSION` | 2304 | **2305** |
| `package.json` | 2.3.4 | **2.3.5** |

`app.json` es la fuente de verdad; `scripts/sync-version.js` propaga a package.json e iOS, y Gradle lee app.json directamente.

## Contenido del release

- Filtros del P2P revisados: todos los filtros y órdenes se resuelven en el servidor ahora que el backend los soporta (#16).
- Selector de monedas unificado como bottom sheet, fila rediseñada a dos columnas, caché del catálogo en tres capas (#16).
- Tarjeta de oferta P2P rediseñada al orden de lectura de la industria (#16).
- Botones squircle en toda la app (#16).
- Gema `json` a 2.21.2 por aviso de seguridad (#17).
- Padding inferior memoizado en 18 pantallas (#18).

## Verificación

1465 tests / 130 suites en verde, lint con 0 errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime, security, or business-logic changes in the diff.
> 
> **Overview**
> **Release version bump** from **2.3.4** / **2304** to **2.3.5** / **2305**.
> 
> `app.json` updates `version` and `versionCode`; `package.json` matches the marketing version. iOS `project.pbxproj` sets **MARKETING_VERSION** to 2.3.5 and **CURRENT_PROJECT_VERSION** to 2305 for both the main QvaPay target and the QvaPay Widgets extension (Debug and Release). No application or dependency code changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a40b09309134c49e3aa04ebd21edb32acbe5027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->