### PR TITLE
Mk improvements

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
 	"name": "QvaPay",
 	"displayName": "QvaPay",
-	"version": "2.3.10",
-	"versionCode": 2310
+	"version": "2.3.11",
+	"versionCode": 2311
 }

--- a/auth/screens/Register.jsx
+++ b/auth/screens/Register.jsx
@@ -28,6 +28,10 @@ import usePushPrompt from '../../hooks/usePushPrompt'
 // Nudge de KYC (gracia post-sesión para el banner del Home)
 import { markKycSessionStarted } from '../../hooks/useKycPrompt'
 
+// Atribución de instalación (Android Install Referrer): código del referidor
+// y source de adquisición capturados en el primer arranque
+import { getStoredAttribution, mapSourceToEnum } from '../../helpers/installReferrer'
+
 // UI
 import QPKeyboardView from '../../ui/QPKeyboardView'
 import QPStepDots from '../../ui/particles/QPStepDots'
@@ -128,6 +132,24 @@ const RegisterScreen = ({ navigation }) => {
 	const finishingRef = useRef(false)
 	const lastnameInputRef = useRef(null)
 
+	// Atribución de instalación: si el referrer de Play trajo un código de
+	// invitación, se aplica solo (visible para el usuario); el utm_source viaja
+	// como `source` al crear la cuenta
+	const attributionRef = useRef(null)
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			const attribution = await getStoredAttribution()
+			if (cancelled || !attribution) return
+			attributionRef.current = attribution
+			if (attribution.invite) {
+				dispatch({ type: 'set', field: 'invite', value: attribution.invite })
+				setShowInvite(true)
+			}
+		})()
+		return () => { cancelled = true }
+	}, [])
+
 	// Resend countdown for the phone code
 	const { label: countdownLabel, isDisabled: resendDisabled, start: startCountdown } = usePinCountdown()
 
@@ -189,6 +211,7 @@ const RegisterScreen = ({ navigation }) => {
 				email: email.trim(),
 				password,
 				invite: invite.trim() || undefined,
+				source: mapSourceToEnum(attributionRef.current?.utmSource),
 				terms: true
 			})
 			if (result.success) {

--- a/auth/screens/Register.test.js
+++ b/auth/screens/Register.test.js
@@ -16,6 +16,7 @@ jest.mock('../hooks/usePinCountdown', () => jest.fn())
 jest.mock('../../hooks/useStepTransitions', () => jest.fn())
 jest.mock('../../hooks/usePushPrompt', () => jest.fn())
 jest.mock('../../hooks/useKycPrompt', () => ({ markKycSessionStarted: jest.fn() }))
+jest.mock('../../helpers/installReferrer', () => ({ getStoredAttribution: jest.fn(), mapSourceToEnum: jest.fn() }))
 jest.mock('../../api/authApi', () => ({ authApi: { login: jest.fn() } }))
 jest.mock('../../api/userApi', () => ({ userApi: { verifyPhone: jest.fn(), requestKYCSession: jest.fn() } }))
 jest.mock('../../api/client', () => ({ setAuthToken: jest.fn() }))
@@ -45,6 +46,7 @@ import usePushPrompt from '../../hooks/usePushPrompt'
 import { authApi } from '../../api/authApi'
 import { userApi } from '../../api/userApi'
 import { setAuthToken } from '../../api/client'
+import { getStoredAttribution, mapSourceToEnum } from '../../helpers/installReferrer'
 import { toast } from 'sonner-native'
 import RegisterScreen from './Register'
 
@@ -117,6 +119,8 @@ beforeEach(() => {
 	userApi.verifyPhone.mockResolvedValue({ success: true })
 	completeSession.mockResolvedValue()
 	setAuthToken.mockResolvedValue()
+	getStoredAttribution.mockResolvedValue(null)
+	mapSourceToEnum.mockReturnValue(undefined)
 	enablePush.mockResolvedValue()
 	dismissOnboardPrompt.mockResolvedValue()
 })
@@ -191,6 +195,22 @@ describe('password step and account creation', () => {
 		act(() => { input(tree, 'Contraseña').props.onChangeText('Secret1!') })
 		await press(tree, 'Crear cuenta')
 		expect(register).toHaveBeenCalledWith(expect.objectContaining({ invite: 'AMIGO' }))
+	})
+
+	test('install-referrer attribution prefills the invite code and sends the mapped source', async () => {
+		getStoredAttribution.mockResolvedValue({ utmSource: 'telegram', invite: 'PADRINO' })
+		mapSourceToEnum.mockReturnValue('telegram')
+		const tree = renderRegister()
+		await act(async () => {})
+		await goToEmailStep(tree)
+		// The prefetched invite is visible without tapping the reveal toggle
+		expect(input(tree, 'Código de invitación').props.value).toBe('PADRINO')
+		act(() => { input(tree, 'tucorreo@gmail.com').props.onChangeText('john@doe.com') })
+		await press(tree, 'Continuar')
+		act(() => { input(tree, 'Contraseña').props.onChangeText('Secret1!') })
+		await press(tree, 'Crear cuenta')
+		expect(mapSourceToEnum).toHaveBeenCalledWith('telegram')
+		expect(register).toHaveBeenCalledWith(expect.objectContaining({ invite: 'PADRINO', source: 'telegram' }))
 	})
 
 	test('a failed registration toasts the backend error and stays on the password step', async () => {

--- a/helpers/installReferrer.js
+++ b/helpers/installReferrer.js
@@ -1,0 +1,101 @@
+import { Platform } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+const CONSUMED_KEY = '@qvapay:installReferrerConsumed'
+const ATTRIBUTION_KEY = '@qvapay:installAttribution'
+
+// Only paths the app knows how to open (see linking.js / useAppNavigation parsers)
+const VALID_LINK_PREFIXES = ['/p2p/', '/pay/', '/store/']
+
+/**
+ * Parses the raw Google Play Install Referrer string into campaign attribution.
+ * Expected shape: `utm_source=telegram&utm_campaign=tasas&qp_link=%2Fp2p%2F<uuid>&invite=<username>`.
+ * The whole string may arrive URL-encoded one extra time (Play passes the
+ * `referrer` param through verbatim), so a `%3D`-only string is decoded first.
+ * @param {string} raw - Referrer string from the Play Install Referrer API
+ * @returns {{ utmSource: string|null, utmMedium: string|null, utmCampaign: string|null, qpLink: string|null, invite: string|null }|null}
+ *   Parsed attribution, or null for organic installs and unusable strings.
+ */
+export const parseInstallReferrer = (raw) => {
+
+	if (!raw || typeof raw !== 'string') return null
+	let referrer = raw.trim()
+	if (!referrer || referrer === 'unknown') return null
+	// Double-encoded referrer: no bare "=" but encoded ones — decode once more
+	if (!referrer.includes('=') && referrer.includes('%3D')) { try { referrer = decodeURIComponent(referrer) } catch { return null } }
+
+	const params = {}
+	for (const pair of referrer.split('&')) {
+		const eq = pair.indexOf('=')
+		if (eq <= 0) continue
+		try {
+			params[decodeURIComponent(pair.slice(0, eq))] = decodeURIComponent(pair.slice(eq + 1))
+		} catch { /* skip malformed pair */ }
+	}
+
+	const utmSource = params.utm_source || null
+	const utmMedium = params.utm_medium || null
+	if (utmSource === 'google-play' && utmMedium === 'organic') return null
+
+	let qpLink = params.qp_link || null
+	if (qpLink && !VALID_LINK_PREFIXES.some(prefix => qpLink.startsWith(prefix))) qpLink = null
+
+	const attribution = {
+		utmSource,
+		utmMedium,
+		utmCampaign: params.utm_campaign || null,
+		qpLink,
+		invite: params.invite || null,
+	}
+	const meaningful = attribution.utmSource || attribution.utmCampaign || attribution.qpLink || attribution.invite
+	return meaningful ? attribution : null
+}
+
+/**
+ * Maps a free-form utm_source onto the backend's registration source enum
+ * (`sms|telegram|x|facebook|link` — POST /auth/register rejects anything else
+ * with a 400, so unknown campaign sources collapse to the generic `link`).
+ * @param {string|null|undefined} utmSource - utm_source from the install referrer
+ * @returns {string|undefined} A valid enum value, or undefined when there is no source
+ */
+export const mapSourceToEnum = (utmSource) => {
+	if (!utmSource) return undefined
+	const source = utmSource.toLowerCase()
+	if (source === 'telegram') return 'telegram'
+	if (source === 'facebook' || source === 'fb') return 'facebook'
+	if (source === 'x' || source === 'twitter') return 'x'
+	if (source === 'sms') return 'sms'
+	return 'link'
+}
+
+/**
+ * Reads the Play Install Referrer once per install (Android only) and persists
+ * the parsed attribution. Subsequent calls (and every call on iOS) resolve to
+ * null. Errors never propagate — a failed read just retries on the next launch.
+ * @returns {Promise<ReturnType<typeof parseInstallReferrer>>} The attribution captured on this call, or null.
+ */
+export const consumeInstallReferrer = async () => {
+	if (Platform.OS !== 'android') return null
+	try {
+		if (await AsyncStorage.getItem(CONSUMED_KEY)) return null
+		const raw = await DeviceInfo.getInstallReferrer()
+		const attribution = parseInstallReferrer(raw)
+		if (attribution) await AsyncStorage.setItem(ATTRIBUTION_KEY, JSON.stringify(attribution))
+		await AsyncStorage.setItem(CONSUMED_KEY, '1')
+		return attribution
+	} catch { return null }
+}
+
+/**
+ * Returns the attribution captured by `consumeInstallReferrer()` on the first
+ * launch, for flows that run later (e.g. the register wizard picking up the
+ * inviter's code and the acquisition source).
+ * @returns {Promise<ReturnType<typeof parseInstallReferrer>>}
+ */
+export const getStoredAttribution = async () => {
+	try {
+		const stored = await AsyncStorage.getItem(ATTRIBUTION_KEY)
+		return stored ? JSON.parse(stored) : null
+	} catch { return null }
+}

--- a/helpers/installReferrer.test.js
+++ b/helpers/installReferrer.test.js
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the install referrer attribution helper — node environment
+ * with react-native, device-info and AsyncStorage mocked (see inAppReview.test.js).
+ * @jest-environment node
+ */
+jest.mock('react-native', () => ({
+	Platform: { OS: 'android' },
+}))
+jest.mock('react-native-device-info', () => ({
+	getInstallReferrer: jest.fn(),
+}))
+jest.mock('@react-native-async-storage/async-storage', () => ({
+	getItem: jest.fn(),
+	setItem: jest.fn(),
+}))
+
+import { Platform } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+	parseInstallReferrer,
+	mapSourceToEnum,
+	consumeInstallReferrer,
+	getStoredAttribution,
+} from './installReferrer'
+
+const CONSUMED_KEY = '@qvapay:installReferrerConsumed'
+const ATTRIBUTION_KEY = '@qvapay:installAttribution'
+
+beforeEach(() => {
+	jest.clearAllMocks()
+	Platform.OS = 'android'
+	AsyncStorage.getItem.mockResolvedValue(null)
+	AsyncStorage.setItem.mockResolvedValue()
+	DeviceInfo.getInstallReferrer.mockResolvedValue(null)
+})
+
+describe('parseInstallReferrer', () => {
+	test('parses a full campaign referrer', () => {
+		expect(parseInstallReferrer('utm_source=telegram&utm_medium=social&utm_campaign=tasas&qp_link=%2Fp2p%2Fabc-123&invite=erich')).toEqual({
+			utmSource: 'telegram',
+			utmMedium: 'social',
+			utmCampaign: 'tasas',
+			qpLink: '/p2p/abc-123',
+			invite: 'erich',
+		})
+	})
+
+	test('decodes a double-encoded referrer', () => {
+		expect(parseInstallReferrer('utm_source%3Dtelegram%26utm_campaign%3Dtasas')).toEqual({
+			utmSource: 'telegram',
+			utmMedium: null,
+			utmCampaign: 'tasas',
+			qpLink: null,
+			invite: null,
+		})
+	})
+
+	test('organic Play installs return null', () => {
+		expect(parseInstallReferrer('utm_source=google-play&utm_medium=organic')).toBeNull()
+	})
+
+	test('empty, unknown and meaningless strings return null', () => {
+		expect(parseInstallReferrer('')).toBeNull()
+		expect(parseInstallReferrer(null)).toBeNull()
+		expect(parseInstallReferrer('unknown')).toBeNull()
+		expect(parseInstallReferrer('gclid=xyz')).toBeNull()
+	})
+
+	test('discards qp_link outside the supported paths but keeps the rest', () => {
+		expect(parseInstallReferrer('utm_campaign=phish&qp_link=%2Fsettings%2Fdanger')).toEqual({
+			utmSource: null,
+			utmMedium: null,
+			utmCampaign: 'phish',
+			qpLink: null,
+			invite: null,
+		})
+	})
+
+	test('invite alone is meaningful (referral links without campaign)', () => {
+		expect(parseInstallReferrer('invite=erich')).toMatchObject({ invite: 'erich' })
+	})
+})
+
+describe('mapSourceToEnum', () => {
+	test('maps known sources onto the backend enum', () => {
+		expect(mapSourceToEnum('telegram')).toBe('telegram')
+		expect(mapSourceToEnum('Facebook')).toBe('facebook')
+		expect(mapSourceToEnum('fb')).toBe('facebook')
+		expect(mapSourceToEnum('twitter')).toBe('x')
+		expect(mapSourceToEnum('x')).toBe('x')
+		expect(mapSourceToEnum('sms')).toBe('sms')
+	})
+
+	test('unknown sources collapse to link, absent to undefined', () => {
+		expect(mapSourceToEnum('newsletter')).toBe('link')
+		expect(mapSourceToEnum(null)).toBeUndefined()
+		expect(mapSourceToEnum('')).toBeUndefined()
+	})
+})
+
+describe('consumeInstallReferrer', () => {
+	test('reads, persists and marks consumed on first launch', async () => {
+		DeviceInfo.getInstallReferrer.mockResolvedValue('utm_source=telegram&invite=erich')
+		const attribution = await consumeInstallReferrer()
+		expect(attribution).toMatchObject({ utmSource: 'telegram', invite: 'erich' })
+		expect(AsyncStorage.setItem).toHaveBeenCalledWith(ATTRIBUTION_KEY, JSON.stringify(attribution))
+		expect(AsyncStorage.setItem).toHaveBeenCalledWith(CONSUMED_KEY, '1')
+	})
+
+	test('second call is a no-op (one shot per install)', async () => {
+		AsyncStorage.getItem.mockResolvedValue('1')
+		await expect(consumeInstallReferrer()).resolves.toBeNull()
+		expect(DeviceInfo.getInstallReferrer).not.toHaveBeenCalled()
+	})
+
+	test('organic referrer still marks consumed without persisting attribution', async () => {
+		DeviceInfo.getInstallReferrer.mockResolvedValue('utm_source=google-play&utm_medium=organic')
+		await expect(consumeInstallReferrer()).resolves.toBeNull()
+		expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+		expect(AsyncStorage.setItem).toHaveBeenCalledWith(CONSUMED_KEY, '1')
+	})
+
+	test('iOS resolves to null without touching anything', async () => {
+		Platform.OS = 'ios'
+		await expect(consumeInstallReferrer()).resolves.toBeNull()
+		expect(DeviceInfo.getInstallReferrer).not.toHaveBeenCalled()
+		expect(AsyncStorage.getItem).not.toHaveBeenCalled()
+	})
+
+	test('a native error resolves to null (retries next launch)', async () => {
+		DeviceInfo.getInstallReferrer.mockRejectedValue(new Error('service unavailable'))
+		await expect(consumeInstallReferrer()).resolves.toBeNull()
+		expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(CONSUMED_KEY, '1')
+	})
+})
+
+describe('getStoredAttribution', () => {
+	test('returns the persisted attribution', async () => {
+		AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ utmSource: 'telegram', invite: 'erich' }))
+		await expect(getStoredAttribution()).resolves.toEqual({ utmSource: 'telegram', invite: 'erich' })
+	})
+
+	test('returns null when nothing stored or JSON is corrupt', async () => {
+		await expect(getStoredAttribution()).resolves.toBeNull()
+		AsyncStorage.getItem.mockResolvedValue('{corrupt')
+		await expect(getStoredAttribution()).resolves.toBeNull()
+	})
+})

--- a/helpers/referralLinks.js
+++ b/helpers/referralLinks.js
@@ -1,0 +1,47 @@
+// Builders for the referral invite links shared from settings/Referals.
+// Android gets the Play Store URL with the invite embedded in the Install
+// Referrer (auto-applied on the invitee's register — see installReferrer.js);
+// iPhone/desktop fall back to the web register URL, which carries the inviter's
+// username in the path. Swap in the App Store URL here once the iOS app leaves
+// TestFlight (no public listing as of 2026-08).
+
+const PLAY_STORE_BASE = 'https://play.google.com/store/apps/details?id=com.qvapay'
+const WEB_REGISTER_BASE = 'https://www.qvapay.com/register'
+
+/**
+ * Builds the Play Store install link with the referral embedded in the
+ * `referrer` param (single URL-encoded, as Play expects). On the invitee's
+ * first launch `consumeInstallReferrer()` reads it back and the register
+ * wizard prefills the invite code and acquisition source.
+ * @param {string} username - The inviter's username
+ * @param {string} [source] - Share channel (telegram|x|facebook|sms|link)
+ * @returns {string} Play Store URL with referral attribution
+ */
+export const buildPlayReferralLink = (username, source = 'link') => {
+	const referrer = `invite=${username}&utm_source=${source}&utm_medium=referral&utm_campaign=referidos`
+	return `${PLAY_STORE_BASE}&referrer=${encodeURIComponent(referrer)}`
+}
+
+/**
+ * Builds the web register link with the inviter's username in the path —
+ * the fallback for iPhone and desktop while there is no App Store listing.
+ * @param {string} username - The inviter's username
+ * @param {string} [source] - Share channel tag appended as query param
+ * @returns {string} Web registration URL
+ */
+export const buildWebReferralLink = (username, source) =>
+	`${WEB_REGISTER_BASE}/${username}${source ? `?source=${source}` : ''}`
+
+/**
+ * Composes the multiplatform invite message shared through the social
+ * buttons: Play link (referral auto-applied) + web link for everyone else,
+ * with the code spelled out for paths that can't carry it.
+ * @param {string} username - The inviter's username
+ * @param {string} [source] - Share channel (tags both links)
+ * @returns {string} Ready-to-share message
+ */
+export const buildReferralMessage = (username, source) => [
+	`Únete a QvaPay con mi código de invitación: ${username}`,
+	`📲 Android: ${buildPlayReferralLink(username, source)}`,
+	`🌐 iPhone y web: ${buildWebReferralLink(username, source)}`,
+].join('\n')

--- a/helpers/referralLinks.test.js
+++ b/helpers/referralLinks.test.js
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the referral invite link builders — node environment, pure
+ * string logic. The round-trip test proves the Play link's referrer decodes
+ * into exactly what installReferrer.js expects on the invitee's first launch.
+ * @jest-environment node
+ */
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }))
+jest.mock('react-native-device-info', () => ({ getInstallReferrer: jest.fn() }))
+jest.mock('@react-native-async-storage/async-storage', () => ({ getItem: jest.fn(), setItem: jest.fn() }))
+
+import { buildPlayReferralLink, buildWebReferralLink, buildReferralMessage } from './referralLinks'
+import { parseInstallReferrer, mapSourceToEnum } from './installReferrer'
+
+describe('buildPlayReferralLink', () => {
+	test('embeds the referral in a single URL-encoded referrer param', () => {
+		expect(buildPlayReferralLink('erich', 'telegram')).toBe(
+			'https://play.google.com/store/apps/details?id=com.qvapay&referrer=' +
+			encodeURIComponent('invite=erich&utm_source=telegram&utm_medium=referral&utm_campaign=referidos'),
+		)
+	})
+
+	test('round-trips through the install referrer parser with the register enum intact', () => {
+		const url = buildPlayReferralLink('erich', 'telegram')
+		// Play hands the app the decoded referrer param value
+		const rawReferrer = decodeURIComponent(url.split('&referrer=')[1])
+		const attribution = parseInstallReferrer(rawReferrer)
+		expect(attribution).toMatchObject({ invite: 'erich', utmSource: 'telegram', utmCampaign: 'referidos' })
+		expect(mapSourceToEnum(attribution.utmSource)).toBe('telegram')
+	})
+
+	test('defaults the source to link (valid register enum)', () => {
+		const rawReferrer = decodeURIComponent(buildPlayReferralLink('erich').split('&referrer=')[1])
+		expect(mapSourceToEnum(parseInstallReferrer(rawReferrer).utmSource)).toBe('link')
+	})
+})
+
+describe('buildWebReferralLink', () => {
+	test('keeps the username in the path with the channel tag', () => {
+		expect(buildWebReferralLink('erich', 'x')).toBe('https://www.qvapay.com/register/erich?source=x')
+		expect(buildWebReferralLink('erich')).toBe('https://www.qvapay.com/register/erich')
+	})
+})
+
+describe('buildReferralMessage', () => {
+	test('carries the code and both platform links', () => {
+		const msg = buildReferralMessage('erich', 'sms')
+		expect(msg).toContain('código de invitación: erich')
+		expect(msg).toContain(buildPlayReferralLink('erich', 'sms'))
+		expect(msg).toContain(buildWebReferralLink('erich', 'sms'))
+	})
+})

--- a/hooks/useAppNavigation.js
+++ b/hooks/useAppNavigation.js
@@ -6,13 +6,21 @@ import { useEffect, useState } from 'react'
 import { Linking } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
 import { OneSignal } from 'react-native-onesignal'
+
+// Toast
 import { toast } from 'sonner-native'
 
+// Contexts
 import { useAuth } from '../auth/AuthContext'
 import { useSettings } from '../settings/SettingsContext'
+
+// Routes
 import { ROUTES } from '../routes'
+
+// Helpers
 import playSound from '../helpers/playSound'
 import { maybePromptUpdate } from '../helpers/versionCheck'
+import { consumeInstallReferrer } from '../helpers/installReferrer'
 
 /**
  * Parses the P2P offer UUID out of a deep link URL.
@@ -81,7 +89,7 @@ export function useAppNavigation(pendingDeepLinkRef) {
 
 	// Update prompt state
 	const [updateInfo, setUpdateInfo] = useState(
-		/** @type {{ needsUpdate: boolean; currentVersion?: string; latestVersion?: string; storeUrl?: string } | null} */ (null),
+		/** @type {{ needsUpdate: boolean; currentVersion?: string; latestVersion?: string; storeUrl?: string } | null} */(null),
 	)
 
 	useEffect(() => {
@@ -90,6 +98,17 @@ export function useAppNavigation(pendingDeepLinkRef) {
 		}, 2000)
 		return () => clearTimeout(timer)
 	}, [])
+
+	// Deferred deep link (Android Install Referrer): on the first launch after a
+	// Play install, the campaign link may carry a destination (`qp_link`). It is
+	// queued in pendingDeepLinkRef so the auth reconciliation below opens it
+	// after login/registration — same path a pre-auth universal link takes.
+	useEffect(() => {
+		(async () => {
+			const attribution = await consumeInstallReferrer()
+			if (attribution?.qpLink && !pendingDeepLinkRef.current) { pendingDeepLinkRef.current = `https://www.qvapay.com${attribution.qpLink}` }
+		})()
+	}, [pendingDeepLinkRef])
 
 	// Check for store update on app launch
 	useEffect(() => {

--- a/hooks/useAppNavigation.test.js
+++ b/hooks/useAppNavigation.test.js
@@ -28,6 +28,7 @@ jest.mock('sonner-native', () => ({ toast: { info: jest.fn(), success: jest.fn()
 jest.mock('../auth/AuthContext', () => ({ useAuth: jest.fn() }))
 jest.mock('../settings/SettingsContext', () => ({ useSettings: jest.fn() }))
 jest.mock('../helpers/playSound', () => jest.fn())
+jest.mock('../helpers/installReferrer', () => ({ consumeInstallReferrer: jest.fn() }))
 jest.mock('../helpers/versionCheck', () => ({ maybePromptUpdate: jest.fn() }))
 
 import React from 'react'
@@ -38,6 +39,7 @@ import { toast } from 'sonner-native'
 import { useAuth } from '../auth/AuthContext'
 import { useSettings } from '../settings/SettingsContext'
 import playSound from '../helpers/playSound'
+import { consumeInstallReferrer } from '../helpers/installReferrer'
 import { maybePromptUpdate } from '../helpers/versionCheck'
 import { useAppNavigation } from './useAppNavigation'
 
@@ -74,6 +76,7 @@ beforeEach(() => {
 		isLoading: false,
 	})
 	maybePromptUpdate.mockResolvedValue({ needsUpdate: false })
+	consumeInstallReferrer.mockResolvedValue(null)
 	Linking.getInitialURL.mockResolvedValue(null)
 	navigation.getState.mockReturnValue({ index: 0, routes: [{ name: 'Splash' }] })
 })
@@ -247,5 +250,40 @@ describe('OneSignal listeners', () => {
 			oneSignalListeners.click({ notification: { additionalData: { type: 'transaction', uuid: 't-1' } } })
 		})
 		expect(navigation.navigate).not.toHaveBeenCalled()
+	})
+})
+
+describe('install referrer deferred deep link', () => {
+	test('queues the campaign destination for the post-login reconciliation', async () => {
+		useAuth.mockReturnValue({ user: null, isAuthenticated: false, isLoading: false })
+		consumeInstallReferrer.mockResolvedValue({ qpLink: `/p2p/${P2P_UUID}` })
+		const { pendingRef } = await renderAppNav()
+		expect(pendingRef.current).toBe(`https://www.qvapay.com/p2p/${P2P_UUID}`)
+	})
+
+	test('an authenticated first launch opens the campaign screen directly', async () => {
+		consumeInstallReferrer.mockResolvedValue({ qpLink: `/p2p/${P2P_UUID}` })
+		await renderAppNav()
+		await passSplash()
+		expect(navigation.reset).toHaveBeenCalledWith({
+			index: 1,
+			routes: [
+				{ name: 'MainStack' },
+				{ name: 'P2POffer', params: { p2p_uuid: P2P_UUID } },
+			],
+		})
+	})
+
+	test('organic installs leave the pending ref untouched', async () => {
+		const { pendingRef } = await renderAppNav()
+		expect(pendingRef.current).toBeNull()
+	})
+
+	test('never overwrites a deep link already queued', async () => {
+		consumeInstallReferrer.mockResolvedValue({ qpLink: `/p2p/${P2P_UUID}` })
+		const pendingRef = { current: `https://qvapay.com/pay/${P2P_UUID}` }
+		useAuth.mockReturnValue({ user: null, isAuthenticated: false, isLoading: false })
+		await renderAppNav(pendingRef)
+		expect(pendingRef.current).toBe(`https://qvapay.com/pay/${P2P_UUID}`)
 	})
 })

--- a/screens/settings/subpanels/Referals.jsx
+++ b/screens/settings/subpanels/Referals.jsx
@@ -26,6 +26,7 @@ import { toast } from 'sonner-native'
 
 // Helpers
 import { copyTextToClipboard } from '../../../helpers'
+import { buildPlayReferralLink, buildWebReferralLink, buildReferralMessage } from '../../../helpers/referralLinks'
 
 // Online Status
 import { useOnlineStatus } from '../../../hooks/OnlineStatusContext'
@@ -74,8 +75,10 @@ const Referals = () => {
 	const loading = query.isPending
 	const [refreshing, setRefreshing] = useState(false)
 
-	// Referral link
-	const referralLink = `https://www.qvapay.com/register/${user.username}`
+	// Referral link shown in the copy box (short); the share buttons send the
+	// multiplatform invite (Play link with the invite embedded in the Install
+	// Referrer + web fallback for iPhone/desktop)
+	const referralLink = buildWebReferralLink(user.username)
 
 	// El toast solo cuando no hay NADA que pintar
 	useEffect(() => {
@@ -98,32 +101,32 @@ const Referals = () => {
 		return () => { if (ids.length) untrackUsers(ids) }
 	}, [referrals, trackUsers, untrackUsers])
 
-	// Copy referral link
+	// Copy the full multiplatform invite (for WhatsApp and any other channel)
 	const handleCopyLink = () => {
-		copyTextToClipboard(referralLink)
-		toast.success('Enlace copiado al portapapeles')
+		copyTextToClipboard(buildReferralMessage(user.username, 'link'))
+		toast.success('Invitación copiada al portapapeles')
 	}
 
-	// Social share handlers
+	// Social share handlers — text channels carry the full invite message;
+	// Facebook's sharer only accepts a URL, so it gets the Play link directly
 	const shareToX = () => shareWithTracking('x', () => {
-		const link = `${referralLink}?source=x`
-		const msg = `Únete a QvaPay usando mi enlace de referido: ${link}`
+		const msg = buildReferralMessage(user.username, 'x')
 		Linking.openURL(`https://x.com/intent/tweet?text=${encodeURIComponent(msg)}`)
 	})
 
 	const shareToFacebook = () => shareWithTracking('facebook', () => {
-		const link = `${referralLink}?source=facebook`
+		const link = buildPlayReferralLink(user.username, 'facebook')
 		Linking.openURL(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(link)}`)
 	})
 
 	const shareToTelegram = () => shareWithTracking('telegram', () => {
-		const link = `${referralLink}?source=telegram`
-		Linking.openURL(`https://t.me/share/url?url=${encodeURIComponent(link)}&text=${encodeURIComponent('Únete a QvaPay usando mi enlace de referido')}`)
+		const link = buildPlayReferralLink(user.username, 'telegram')
+		const text = `Únete a QvaPay con mi código de invitación: ${user.username}\n🌐 iPhone y web: ${buildWebReferralLink(user.username, 'telegram')}`
+		Linking.openURL(`https://t.me/share/url?url=${encodeURIComponent(link)}&text=${encodeURIComponent(text)}`)
 	})
 
 	const shareToSMS = () => shareWithTracking('sms', () => {
-		const link = `${referralLink}?source=sms`
-		const msg = `Únete a QvaPay usando mi enlace de referido: ${link}`
+		const msg = buildReferralMessage(user.username, 'sms')
 		const separator = Platform.OS === 'ios' ? '&' : '?'
 		Linking.openURL(`sms:${separator}body=${encodeURIComponent(msg)}`)
 	})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches registration payloads and first-launch navigation/deep-link queuing; mistakes could mis-attribute signups or route users to wrong screens, though `qp_link` is allowlisted and unknown sources map to safe enum values.
> 
> **Overview**
> **Adds end-to-end referral attribution on Android** using the Google Play Install Referrer: a new helper reads and parses the referrer once per install (invite code, UTM fields, optional `qp_link`), persists it, and maps `utm_source` to the backend registration `source` enum.
> 
> On **first launch**, `useAppNavigation` consumes the referrer and, when present, queues a campaign `qp_link` as a deferred deep link (same post-login path as universal links). The **register wizard** loads stored attribution to prefill the invite field and sends `invite` + `source` on account creation.
> 
> **Referrals settings** now builds Play Store URLs with the invite embedded in the referrer param, web register fallbacks, and a multiplatform copy/share message; social share handlers use those builders instead of a single web URL.
> 
> App version bumps to **2.3.11**; unit tests cover parsing, consumption, link round-trips, navigation queuing, and register prefill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1348aeed2d7e0b17981ef8a2a9474cf9c86fdccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->