### PR TITLE
chore(ci): run ESLint and Jest on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint + Jest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: Tests
+        run: npm test -- --ci


### PR DESCRIPTION
Split from #24 (as requested in review): the CI workflow travels separately so the bugfix PR stays surgical.

## What

Single-job workflow (`checkout` + `npm ci` shared) running `npm run lint` and `npm test -- --ci` on every PR and on pushes to `main`.

## Notes

- Unified into one job per the review suggestion — no duplicated setup steps.
- Coexists with the existing `react-doctor.yml`: complementary scopes (code quality vs project diagnostics); each has its own concurrency group so they don't cancel each other.
- Node 22 (matches the repo's engine requirement) with npm cache enabled.