### PR TITLE
feat(kyc): gate de verificación en Extraer y USD CASH

### DIFF
--- a/screens/home/Home.jsx
+++ b/screens/home/Home.jsx
@@ -240,8 +240,9 @@ const Home = ({ navigation }) => {
 					)}
 				</View>
 
-				{/* Cash Delivery Card - only show when balance >= 200 */}
-				{Number(user.balance) >= 200 && (<CashDeliveryCard navigation={navigation} />)}
+				{/* Cash Delivery Card: con KYC solo desde balance >= 200; sin KYC
+				    se muestra siempre, sombreada y gateada (invita a verificarse) */}
+				{(!user.kyc || Number(user.balance) >= 200) && (<CashDeliveryCard navigation={navigation} />)}
 
 				{/* Service Cards */}
 				<View style={styles.section}>

--- a/ui/ActionButtons.jsx
+++ b/ui/ActionButtons.jsx
@@ -5,6 +5,11 @@ import Animated, { runOnJS, useAnimatedReaction, useAnimatedStyle } from 'react-
 // Theme Context
 import { useTheme } from '../theme/ThemeContext'
 
+// Auth & KYC gate
+import { useAuth } from '../auth/AuthContext'
+import useKycGate from '../hooks/useKycGate'
+import KycGateModal from './KycGateModal'
+
 // UI
 import QPPressable from './particles/QPPressable'
 
@@ -20,7 +25,7 @@ const ROW_HEIGHT = 56
 // Tile de la cuenta principal (icono arriba, label abajo). El desplazamiento
 // es un parallax escalonado por índice: cada tile sale un poco más lejos que
 // el anterior, siguiendo el dedo en tiempo real (pageProgress 0→1).
-const AccountTile = ({ icon, label, onPress, index, pageProgress, theme }) => {
+const AccountTile = ({ icon, label, onPress, index, pageProgress, theme, dimmed }) => {
 	const style = useAnimatedStyle(() => {
 		const p = pageProgress ? pageProgress.value : 0
 		return {
@@ -34,8 +39,8 @@ const AccountTile = ({ icon, label, onPress, index, pageProgress, theme }) => {
 	return (
 		<Animated.View style={[styles.tileSlot, style]}>
 			<QPPressable onPress={onPress} style={[styles.tile, { backgroundColor: theme.colors.elevation }]}>
-				<FontAwesome6 name={icon} size={17} color={theme.colors.primaryText} iconStyle="solid" />
-				<Text style={[styles.tileLabel, { color: theme.colors.primaryText, fontSize: theme.typography.fontSize.xs, fontFamily: theme.typography.fontFamily.medium }]}>
+				<FontAwesome6 name={icon} size={17} color={dimmed ? theme.colors.tertiaryText : theme.colors.primaryText} iconStyle="solid" />
+				<Text style={[styles.tileLabel, { color: dimmed ? theme.colors.tertiaryText : theme.colors.primaryText, fontSize: theme.typography.fontSize.xs, fontFamily: theme.typography.fontFamily.medium }]}>
 					{label}
 				</Text>
 			</QPPressable>
@@ -87,6 +92,12 @@ const ActionButtons = ({ navigation, pageProgress }) => {
 	// Theme variables, dark and light modes with memoized styles
 	const { theme } = useTheme()
 
+	// Extraer requiere identidad verificada: sin KYC el tile se atenúa y el
+	// toque abre el KycGateModal (con salto a verificación) en vez de navegar
+	const { user } = useAuth()
+	const kycVerified = !!user?.kyc
+	const { requireKyc, gateVisible, gateMessage, closeGate } = useKycGate()
+
 	// Qué fila recibe los toques (los estilos animados siguen el dedo; el
 	// pointerEvents cambia al cruzar la mitad del swipe)
 	const [savingsActive, setSavingsActive] = useState(false)
@@ -99,7 +110,15 @@ const ActionButtons = ({ navigation, pageProgress }) => {
 
 	const accountActions = [
 		{ icon: 'plus', label: 'Depositar', onPress: () => navigation.navigate(ROUTES.ADD) },
-		{ icon: 'turn-up', label: 'Extraer', onPress: () => navigation.navigate(ROUTES.WITHDRAW) },
+		{
+			icon: 'turn-up',
+			label: 'Extraer',
+			dimmed: !kycVerified,
+			onPress: () => {
+				if (!requireKyc({ message: 'Para extraer fondos necesitas tener tu identidad verificada. Es rápido y solo se hace una vez.' })) return
+				navigation.navigate(ROUTES.WITHDRAW)
+			},
+		},
 		{ icon: 'paper-plane', label: 'Enviar', onPress: () => navigation.navigate(ROUTES.SEND) },
 		// P2P es un tab hermano del Home dentro de MainStack, así que el
 		// navigate directo lo resuelve el tab navigator
@@ -128,6 +147,8 @@ const ActionButtons = ({ navigation, pageProgress }) => {
 					<SavingsPill key={action.label} {...action} index={index} pageProgress={pageProgress} theme={theme} />
 				))}
 			</View>
+
+			<KycGateModal visible={gateVisible} message={gateMessage} onClose={closeGate} />
 		</View>
 	)
 }

--- a/ui/ActionButtons.test.js
+++ b/ui/ActionButtons.test.js
@@ -22,6 +22,11 @@ jest.mock('react-native-reanimated', () => {
 })
 jest.mock('./particles/QPPressable', () => 'QPPressable')
 jest.mock('@react-native-vector-icons/fontawesome6', () => 'FontAwesome6')
+jest.mock('./KycGateModal', () => 'KycGateModal')
+
+// Usuario verificado por defecto; los tests de gate lo vacían
+let mockUser = { kyc: true }
+jest.mock('../auth/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }))
 
 import React from 'react'
 import { act, create } from 'react-test-renderer'
@@ -46,6 +51,8 @@ const renderRow = (navigation = { navigate: jest.fn() }) => {
 	return tree
 }
 
+afterEach(() => { mockUser = { kyc: true } })
+
 test('renderiza los 4 tiles de la cuenta y las 2 pills de ahorros', () => {
 	const tree = renderRow()
 	expect(labelsOf(tree)).toEqual(['Depositar', 'Extraer', 'Enviar', 'Comerciar', 'Depositar', 'Retirar'])
@@ -62,6 +69,31 @@ test('los tiles de la cuenta navegan a Add / Withdraw / Send / P2P', () => {
 	expect(navigation.navigate).toHaveBeenLastCalledWith(ROUTES.P2P_SCREEN)
 	pressByLabel(tree, 'Depositar', 0)
 	expect(navigation.navigate).toHaveBeenLastCalledWith(ROUTES.ADD)
+})
+
+test('sin KYC, Extraer no navega: se atenúa y abre el KycGateModal', () => {
+	mockUser = { kyc: false }
+	const navigation = { navigate: jest.fn() }
+	const tree = renderRow(navigation)
+
+	// El tile se pinta atenuado (tinta terciaria en vez de primaria)
+	const { createTheme } = jest.requireActual('../theme/ThemeContext')
+	const theme = createTheme(true)
+	const extraerTile = tree.root.findAllByType('QPPressable').find((p) =>
+		p.findAllByType('Text').some((t) => t.props.children === 'Extraer')
+	)
+	expect(extraerTile.findByType('FontAwesome6').props.color).toBe(theme.colors.tertiaryText)
+
+	pressByLabel(tree, 'Extraer')
+	expect(navigation.navigate).not.toHaveBeenCalled()
+
+	const modal = tree.root.findByType('KycGateModal')
+	expect(modal.props.visible).toBe(true)
+	expect(modal.props.message).toMatch(/identidad verificada/)
+
+	// Cerrar el modal lo desmonta del estado del gate
+	act(() => { modal.props.onClose() })
+	expect(tree.root.findByType('KycGateModal').props.visible).toBe(false)
 })
 
 test('las pills de ahorros abren Savings con la acción pre-cargada', () => {

--- a/ui/CashDeliveryCard.jsx
+++ b/ui/CashDeliveryCard.jsx
@@ -6,6 +6,11 @@ import Svg, { Path } from 'react-native-svg'
 import { ROUTES } from '../routes'
 import { useTheme } from '../theme/ThemeContext'
 
+// Auth & KYC gate
+import { useAuth } from '../auth/AuthContext'
+import useKycGate from '../hooks/useKycGate'
+import KycGateModal from './KycGateModal'
+
 // Icons
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
 
@@ -136,12 +141,22 @@ const Courier = ({ routes, initialDelay, msPerPx, scaleX, accent }) => {
  * opens the Withdraw flow with `USDCASH` preselected. Border only appears in
  * light mode (house rule: no borders on dark surfaces).
  *
+ * Sin KYC la card se muestra SOMBREADA (opacidad reducida + fila de acción
+ * con candado) y el toque abre el KycGateModal en vez de navegar — mismo
+ * patrón que el tile Extraer del Home.
+ *
  * @param {object} props
  * @param {object} props.navigation - React Navigation object used for `navigate()`.
  */
 const CashDeliveryCard = ({ navigation }) => {
 
 	const { theme } = useTheme()
+
+	// Enviar efectivo requiere identidad verificada: sin KYC la card queda
+	// sombreada y el toque abre el gate en vez del flujo de retiro
+	const { user } = useAuth()
+	const kycVerified = !!user?.kyc
+	const { requireKyc, gateVisible, gateMessage, closeGate } = useKycGate()
 
 	// Rendered map width (card width). Seeded from the window so overlays are
 	// positioned on first paint; onLayout corrects for iPad/split view.
@@ -178,7 +193,12 @@ const CashDeliveryCard = ({ navigation }) => {
 				Envío de efectivo
 			</Text>
 
-			<Pressable onPress={() => navigation.navigate(ROUTES.WITHDRAW, { preselectedCoin: 'USDCASH' })} style={({ pressed }) => [styles.card, { backgroundColor: theme.colors.surface, transform: [{ scale: pressed ? 0.98 : 1 }] }, theme.mode === 'light' && { borderWidth: 1, borderColor: theme.colors.border }]}>
+			<Pressable
+				onPress={() => {
+					if (!requireKyc({ message: 'Para enviar efectivo con USD CASH necesitas tener tu identidad verificada. Es rápido y solo se hace una vez.' })) return
+					navigation.navigate(ROUTES.WITHDRAW, { preselectedCoin: 'USDCASH' })
+				}}
+				style={({ pressed }) => [styles.card, { backgroundColor: theme.colors.surface, opacity: kycVerified ? 1 : 0.55, transform: [{ scale: pressed ? 0.98 : 1 }] }, theme.mode === 'light' && { borderWidth: 1, borderColor: theme.colors.border }]}>
 
 				{/* Map area */}
 				<View style={styles.mapArea} onLayout={e => setMapWidth(e.nativeEvent.layout.width)}>
@@ -201,14 +221,16 @@ const CashDeliveryCard = ({ navigation }) => {
 					</View>
 				</View>
 
-				{/* Bottom action row */}
+				{/* Bottom action row: sin KYC comunica el porqué del sombreado */}
 				<View style={styles.actionRow}>
-					<Text style={[styles.actionText, { color: theme.colors.primary, fontFamily: theme.typography.fontFamily.semiBold, fontSize: theme.typography.fontSize.md }]}>
-						Enviar efectivo
+					<Text style={[styles.actionText, { color: kycVerified ? theme.colors.primary : theme.colors.secondaryText, fontFamily: theme.typography.fontFamily.semiBold, fontSize: theme.typography.fontSize.md }]}>
+						{kycVerified ? 'Enviar efectivo' : 'Requiere identidad verificada'}
 					</Text>
-					<FontAwesome6 name="chevron-right" size={14} color={theme.colors.primary} iconStyle="solid" />
+					<FontAwesome6 name={kycVerified ? 'chevron-right' : 'lock'} size={14} color={kycVerified ? theme.colors.primary : theme.colors.secondaryText} iconStyle="solid" />
 				</View>
 			</Pressable>
+
+			<KycGateModal visible={gateVisible} message={gateMessage} onClose={closeGate} />
 		</View>
 	)
 }

--- a/ui/CashDeliveryCard.test.js
+++ b/ui/CashDeliveryCard.test.js
@@ -11,6 +11,11 @@ jest.mock('../theme/ThemeContext', () => {
 })
 jest.mock('react-native-reanimated')
 jest.mock('@react-native-vector-icons/fontawesome6', () => 'FontAwesome6')
+jest.mock('./KycGateModal', () => 'KycGateModal')
+
+// Usuario verificado por defecto; los tests del gate lo vacían
+let mockUser = { kyc: true }
+jest.mock('../auth/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }))
 jest.mock('react-native-svg', () => ({
 	__esModule: true,
 	default: 'Svg',
@@ -39,7 +44,7 @@ const renderCard = (navigation = { navigate: jest.fn() }) => {
 const findCardPressable = (tree) =>
 	tree.root.findAll(node => typeof node.props.onPress === 'function')[0]
 
-beforeEach(() => { mockIsDark = true })
+beforeEach(() => { mockIsDark = true; mockUser = { kyc: true } })
 
 test('shows the section title, hero copy and the action row', () => {
 	const out = JSON.stringify(renderCard().toJSON())
@@ -54,6 +59,29 @@ test('tapping the card opens the Withdraw flow with USDCASH preselected', () => 
 	const tree = renderCard(navigation)
 	act(() => { findCardPressable(tree).props.onPress() })
 	expect(navigation.navigate).toHaveBeenCalledWith(ROUTES.WITHDRAW, { preselectedCoin: 'USDCASH' })
+})
+
+test('sin KYC la card queda sombreada, con candado, y el toque abre el gate en vez de navegar', () => {
+	mockUser = { kyc: false }
+	const navigation = { navigate: jest.fn() }
+	const tree = renderCard(navigation)
+
+	// Sombreada + fila de acción con el porqué
+	const card = findCardPressable(tree)
+	expect(JSON.stringify(card.props.style({ pressed: false }))).toContain('"opacity":0.55')
+	const out = JSON.stringify(tree.toJSON())
+	expect(out).toContain('Requiere identidad verificada')
+	expect(out).not.toContain('Enviar efectivo')
+
+	// Inaccesible: no navega, abre el KycGateModal
+	act(() => { card.props.onPress() })
+	expect(navigation.navigate).not.toHaveBeenCalled()
+	const modal = tree.root.findByType('KycGateModal')
+	expect(modal.props.visible).toBe(true)
+	expect(modal.props.message).toMatch(/identidad verificada/)
+
+	act(() => { modal.props.onClose() })
+	expect(tree.root.findByType('KycGateModal').props.visible).toBe(false)
 })
 
 test('draws the vector map from real geography: sea, land and road network', () => {


### PR DESCRIPTION
## Resumen

Sin identidad verificada (`user.kyc`), las dos puertas de retiro del Home quedan visibles pero gateadas, con el patrón de la casa (`useKycGate` + `KycGateModal`):

- **Tile Extraer (`ui/ActionButtons.jsx`)**: se pinta atenuado (tinta terciaria) y el toque abre el modal "Verifica tu identidad" con salto directo a Ajustes → Verificación, en vez de navegar a Withdraw. Con KYC, todo igual que antes.
- **Card USD CASH (`ui/CashDeliveryCard.jsx` + `screens/home/Home.jsx`)**: antes solo se montaba con balance ≥ $200; ahora sin KYC se muestra **siempre**, sombreada (opacidad 0.55) y con la fila de acción convertida en "Requiere identidad verificada" + candado. El toque abre el mismo gate. Con KYC se mantiene la regla de balance ≥ $200 y el flujo normal a Withdraw con `USDCASH` preseleccionado.

Se eligió tile/card visible + modal explicativo en vez de botón muerto u ocultarlos: comunica el porqué y empuja a la verificación.

## Tests

- `ui/ActionButtons.test.js`: sin KYC no navega, se atenúa y el `KycGateModal` abre/cierra con el mensaje.
- `ui/CashDeliveryCard.test.js`: sin KYC hay sombreado + candado, no navega y el modal abre/cierra.
- 11 tests en verde entre ambas suites; ESLint sin errores. Verificado en simulador (iPhone 16 Pro Max) con un usuario sin KYC.

## Pendiente / fuera de alcance

- `screens/scan/Scan.jsx` (bolt11 → Withdraw) y el gate por monto de `Withdraw.jsx` (> $1000) siguen permitiendo el flujo sin KYC. Si la política del backend pasa a exigir KYC para todo retiro, hay que hacer incondicional el gate de Withdraw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Client-side gates on withdraw/cash-delivery entry points affect money-out UX; other routes (e.g. Scan → Withdraw) may still reach Withdraw without KYC per PR notes.
> 
> **Overview**
> Users without verified identity (`user.kyc`) can still see the main **withdraw** entry points on Home, but taps no longer open Withdraw until they verify. Both flows use the existing **`useKycGate`** + **`KycGateModal`** pattern instead of hiding the controls.
> 
> On **`ActionButtons`**, the **Extraer** tile is dimmed and its press handler calls `requireKyc` with a Spanish explanation before navigating to Withdraw. **`CashDeliveryCard`** is dimmed (opacity 0.55), shows “Requiere identidad verificada” with a lock icon, and gates navigation to Withdraw with `USDCASH` preselected the same way.
> 
> **`Home`** changes when the cash-delivery promo mounts: verified users still need balance ≥ $200; unverified users always see the card (gated UI) to encourage verification. Tests in **`ActionButtons.test.js`** and **`CashDeliveryCard.test.js`** cover the no-KYC path (no navigation, modal open/close).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289c9c9397b9a209c61a0157d098ab0d84b2e92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->