### PR TITLE
feat(kyc): embed native identity verification flow in-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This mobile application is the primary gateway to QvaPay. Built with **React Nat
 #### 💰 Money
 - Non-custodial crypto wallet with multi-coin support (40+ networks and fiat rails)
 - USD-equivalent digital balance (QUSD) + **spendable satoshis** (Lightning withdrawals, store discounts, bolt11 scanning)
-- **Card deposits via Stripe** (native PaymentSheet)
+- **Card deposits** with a native payment sheet
 - Instant transfers with PIN/TOTP confirmation and **idempotency keys** on every money operation (safe retries, no double-spends)
 - Merchant invoice payments (Pay screen, deep-linkable)
 - Transaction history with real-time **SSE streaming**, filters, and PDF receipt downloads
@@ -52,14 +52,14 @@ This mobile application is the primary gateway to QvaPay. Built with **React Nat
 - Savings account with **Roundup** (spare-change auto-deposits) and earnings dashboard
 
 #### 🛍️ Store
-- Phone top-ups (Cubacel + Zendit international) and gift cards by country/category
+- Phone top-ups (Cuba + international) and gift cards by country/category
 - **In-app purchase top-ups** billed through App Store / Google Play (consumable IAP)
 - **Personal Shopper**: assisted shopping on Amazon & eBay with cart, tax quotes, and US shipping
 - **Seller Shops** marketplace with local cart and idempotent checkout
 
 #### 🔐 Security & Identity
 - **Passkey login** (WebAuthn), biometric auth (Face ID / fingerprint), 2FA (PIN + TOTP)
-- **KYC verification** powered by Didit (hosted flow with in-app status tracking)
+- **KYC verification** with a hosted flow and in-app status tracking
 - App lock with PIN gate, Keychain-only token storage, leaked-password warnings
 - Failed-login throttling and rate limiting on all sensitive endpoints
 
@@ -89,7 +89,7 @@ This mobile application is the primary gateway to QvaPay. Built with **React Nat
 | 🖌️ Graphics | Skia 2 (SkSL aurora shader) + victory-native 41 (charts) + Lottie 7 |
 | 📷 Camera | Vision Camera 5 + barcode scanner (QR / bolt11) |
 | 🔐 Storage | Keychain (tokens, biometrics, app-lock PIN) + AsyncStorage (settings & cache) |
-| 💳 Payments | Stripe PaymentSheet + react-native-iap 15 (StoreKit / Play Billing) |
+| 💳 Payments | Native payment sheet + react-native-iap 15 (StoreKit / Play Billing) |
 | 🪪 Auth | Bearer tokens + Passkeys (WebAuthn) + biometrics + TOTP |
 | 🔔 Notifications | OneSignal 5 |
 | 🍞 Toasts | sonner-native |
@@ -156,11 +156,11 @@ npm run android       # Run on Android emulator
 - [x] **React Query data layer** — offline-first persisted cache, instant cold starts
 - [x] **Multi-language support (ES/EN/PT-BR)** — full i18next sweep, ~1,900 keys per language
 - [x] **Lightning / spendable satoshis** — LN withdrawals, sats discounts, bolt11 scanning
-- [x] **Card deposits via Stripe** (native PaymentSheet)
+- [x] **Card deposits** (native payment sheet)
 - [x] **In-app purchase top-ups** (StoreKit / Play Billing consumables)
 - [x] **Personal Shopper** — assisted Amazon/eBay shopping with checkout
 - [x] **Seller Shops marketplace** with idempotent checkout
-- [x] **KYC via Didit** — register wizard step, status screen, smart home nudges
+- [x] **KYC flow** — register wizard step, status screen, smart home nudges
 - [x] **Idempotency keys** on all money operations (transfer, withdraw, P2P create)
 - [x] **Price charts** with GOLD scrubbing (victory-native)
 - [x] **Custom app icons for GOLD users** (8 themed variants)
@@ -171,7 +171,7 @@ npm run android       # Run on Android emulator
 - [x] P2P marketplace full lifecycle with client-side filters and rate coloring
 - [x] Savings account with Roundup + Invest dashboard with watchlist
 - [x] Home-screen widgets, push notifications, PDF receipts
-- [x] Phone top-ups and gift cards (unified Zendit catalogs)
+- [x] Phone top-ups and gift cards (unified catalogs)
 - [x] Deep linking (P2P offers, payments, shops) + Android install referrer attribution
 - [x] FlashList migration, haptics, edge-to-edge, light/dark theme, privacy mode
 - [x] R8 shrinking on Android release builds
@@ -200,7 +200,7 @@ We welcome contributions! Please open an issue or submit a pull request. All cod
 
 QvaPay complies with applicable regulations including:
 
-- AML / KYC procedures for user onboarding (Didit-powered verification)
+- AML / KYC procedures for user onboarding
 - Integration with OFAC sanctions list
 - US FinCEN registered MSB (via partners)
 - Ongoing work toward EU licensing under e-Residency

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,3 +155,10 @@ dependencies {
         implementation jscFlavor
     }
 }
+
+// fast-image arrastra com.caverock:androidsvg (jar) y el SDK de Didit la MISMA
+// librería como com.caverock:androidsvg-aar → checkDuplicateClasses revienta.
+// Se excluye el jar plano: el aar sirve las mismas clases 1.4 a ambos.
+configurations.all {
+    exclude group: "com.caverock", module: "androidsvg"
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -22,3 +22,8 @@
 # @stripe/stripe-react-native referencia el módulo opcional de push provisioning
 # (tarjetas en Google Wallet) que no está en el classpath — la app no lo usa
 -dontwarn com.stripe.android.pushProvisioning.**
+
+# SDK nativo de Didit (KYC): binario cerrado con modelos serializados y JNI que
+# R8 full mode no puede rastrear — keep conservador de su grupo completo
+-keep class me.didit.** { *; }
+-dontwarn me.didit.**

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,3 +20,14 @@ buildscript {
 }
 
 apply plugin: "com.facebook.react.rootproject"
+
+allprojects {
+    repositories {
+        // SDK nativo de Didit (KYC). Scoped a su grupo: sin el filtro, Gradle sondea
+        // este host para CADA dependencia y un 429 desactiva el repo a mitad de build.
+        maven {
+            url "https://raw.githubusercontent.com/didit-protocol/sdk-android/main/repository"
+            content { includeGroup "me.didit" }
+        }
+    }
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -42,3 +42,4 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=true
+diditSdkAndroidVariant=autodetection

--- a/api/userApi.js
+++ b/api/userApi.js
@@ -34,15 +34,17 @@ export const userApi = {
 	},
 
 	/**
-	 * Requests a KYC verification session from the DIDIT provider (`POST /user/kyc`).
+	 * Requests a KYC verification session from the identity provider (`POST /user/kyc`).
 	 * Unwraps `response.data.data`, so `data` is the hosted verification URL to open.
+	 * `sessionToken` (when the backend sends it) feeds the native verification SDK;
+	 * without it the caller falls back to opening the hosted URL in the browser.
 	 *
-	 * @returns {Promise<Object>} `{ success, data?, error?, status? }` — `data` is the verification URL string
+	 * @returns {Promise<Object>} `{ success, data?, sessionToken?, error?, status? }` — `data` is the verification URL string
 	 */
 	requestKYCSession: async () => {
 		try {
 			const response = await apiClient.post(`/user/kyc`)
-			return { success: true, data: response.data?.data, status: response.status }
+			return { success: true, data: response.data?.data, sessionToken: response.data?.session_token || null, status: response.status }
 		} catch (error) {
 			if (error.response?.data) {
 				const errorData = error.response.data
@@ -54,9 +56,8 @@ export const userApi = {
 
 	/**
 	 * Gets the current user's KYC status (`GET /user/kyc`).
-	 * `result` is one of: started, processing, passed, failed.
 	 *
-	 * @returns {Promise<Object>} `{ success, data?, raw?, error?, status? }` — `data` is `{ uuid, KYC: { result, country, birthday, document_url, selfie_url } }`, `raw` the unwrapped response body
+	 * @returns {Promise<Object>} `{ success, data?, raw?, error?, status? }` — `data` is `{ uuid, kyc: boolean, kyc_status: 'none'|'pending'|'approved'|'declined' }`, `raw` the unwrapped response body
 	 */
 	getKYCStatus: async () => {
 		try {

--- a/api/userApi.test.js
+++ b/api/userApi.test.js
@@ -84,7 +84,14 @@ describe('userApi KYC', () => {
 		const result = await userApi.requestKYCSession()
 
 		expect(apiClient.post).toHaveBeenCalledWith('/user/kyc')
-		expect(result).toEqual({ success: true, data: 'https://verify.didit.me/session/abc', status: 200 })
+		// Backend sin session_token (despliegue anterior) → null, no undefined
+		expect(result).toEqual({ success: true, data: 'https://verify.didit.me/session/abc', sessionToken: null, status: 200 })
+	})
+
+	test('requestKYCSession expone el session_token del SDK nativo cuando el backend lo manda', async () => {
+		apiClient.post.mockResolvedValue(ok({ data: 'https://verify.didit.me/session/abc', session_token: 'abc' }))
+
+		expect(await userApi.requestKYCSession()).toEqual({ success: true, data: 'https://verify.didit.me/session/abc', sessionToken: 'abc', status: 200 })
 	})
 
 	test('requestKYCSession returns the API error or Spanish fallback', async () => {

--- a/auth/screens/Register.jsx
+++ b/auth/screens/Register.jsx
@@ -1,6 +1,5 @@
 import { usePreventRemove } from '@react-navigation/native'
 import { useState, useRef, useEffect, useEffectEvent, useLayoutEffect, useReducer } from 'react'
-import { Linking } from 'react-native'
 import { useTranslation } from 'react-i18next'
 
 // Routes
@@ -26,8 +25,8 @@ import useStepTransitions from '../../hooks/useStepTransitions'
 // Push notifications (OneSignal permission + flags de prompts)
 import usePushPrompt from '../../hooks/usePushPrompt'
 
-// Nudge de KYC (gracia post-sesión para el banner del Home)
-import { markKycSessionStarted } from '../../hooks/useKycPrompt'
+// Flujo de verificación de identidad nativo (SDK embebido, fallback a navegador)
+import useKycVerification from '../../hooks/useKycVerification'
 
 // Atribución de instalación (Android Install Referrer): código del referidor
 // y source de adquisición capturados en el primer arranque
@@ -92,6 +91,9 @@ const RegisterScreen = ({ navigation }) => {
 
 	// Auth Context
 	const { register, clearError, completeSession } = useAuth()
+
+	// Verificación de identidad nativa (paso kyc del wizard)
+	const { launchKyc } = useKycVerification()
 
 	// Theme variables, dark and light modes
 	const { theme } = useTheme()
@@ -308,25 +310,42 @@ const RegisterScreen = ({ navigation }) => {
 		if (isPushEnabled) { finish() } else { goTo(STEPS.indexOf('push')) }
 	}
 
-	// Abre la sesión de verificación de Didit en el navegador. Los códigos del
-	// backend se mapean a avanzar (400 ya verificado, 409 en revisión, 403
-	// rechazado/max intentos — nada accionable en el wizard) o a reintentar
+	// Lanza el flujo de verificación NATIVO (useKycVerification). Un resultado
+	// terminal avanza el wizard (aprobada/en revisión — nada más que hacer aquí);
+	// cancelar se queda en el paso con el "Ahora no" disponible; solo el fallback
+	// a navegador conserva el estado kycOpened de la vuelta manual
 	const handleStartKyc = async () => {
 		setIsLoading(true)
 		try {
-			const resp = await userApi.requestKYCSession()
-			if (resp.success && resp.data) {
+			const resp = await launchKyc()
+
+			if (resp.kind === 'native') {
+				if (resp.outcome === 'approved') {
+					toast.success(t('auth.register.toasts.kycApproved'))
+					goToPushOrFinish()
+				} else if (resp.outcome === 'pending' || resp.outcome === 'declined') {
+					// declined también se comunica como revisión (política: la revisión
+					// manual la resuelve el equipo, no es un rechazo terminal en el alta)
+					toast.info(t('auth.register.toasts.kycInReview'))
+					goToPushOrFinish()
+				}
+				// cancelled: sin ruido, el paso sigue ofreciendo verificar o "Ahora no"
+			} else if (resp.kind === 'browser') {
 				setKycOpened(true)
-				markKycSessionStarted()
-				await Linking.openURL(resp.data)
-			} else if (resp.status === 409 || resp.status === 400) {
-				if (resp.status === 409) toast.info(t('auth.register.toasts.kycInReview'))
-				goToPushOrFinish()
-			} else if (resp.status === 403) {
-				toast.error(String(resp.error || t('auth.register.toasts.kycStartFailed')))
-				goToPushOrFinish()
+			} else if (resp.kind === 'request-error') {
+				// 400 ya verificado, 409 en revisión, 403 rechazado — nada accionable
+				if (resp.status === 409 || resp.status === 400) {
+					if (resp.status === 409) toast.info(t('auth.register.toasts.kycInReview'))
+					goToPushOrFinish()
+				} else if (resp.status === 403) {
+					toast.error(String(resp.message || t('auth.register.toasts.kycStartFailed')))
+					goToPushOrFinish()
+				} else {
+					toast.error(String(resp.message || t('auth.register.toasts.kycStartFailed')))
+				}
 			} else {
-				toast.error(String(resp.error || t('auth.register.toasts.kycStartFailed')))
+				// sdk-error: reintentable desde el propio paso
+				toast.error(String(resp.message || t('auth.register.toasts.kycStartFailed')))
 			}
 		} catch {
 			toast.error(t('auth.register.toasts.connectionError'))

--- a/hooks/useKycVerification.js
+++ b/hooks/useKycVerification.js
@@ -1,0 +1,107 @@
+import { useCallback, useState } from 'react'
+import { Linking } from 'react-native'
+import { startVerification, VerificationStatus } from '@didit-protocol/sdk-react-native'
+
+// API
+import { userApi } from '../api/userApi'
+
+// Auth
+import { useAuth } from '../auth/AuthContext'
+
+// Nudge de KYC (gracia post-sesión para el banner del Home)
+import { markKycSessionStarted } from './useKycPrompt'
+
+// i18n en call-time: el hook mantiene identidad estable y el idioma del SDK
+// se resuelve al lanzar, no al montar
+import i18n from '../i18n'
+
+// El SDK usa códigos ISO 639-1 con variantes regionales; nuestro 'pt' es Brasil
+const SDK_LANGUAGE = { pt: 'pt-BR' }
+
+/**
+ * Lanza la verificación de identidad NATIVA (SDK del proveedor embebido en la
+ * app). Pide la sesión al backend (`POST /user/kyc`), lanza el flujo nativo con
+ * el `session_token` y mapea el resultado a un objeto discriminado por `kind`
+ * que cada superficie (pantalla de Ajustes, wizard de Registro) traduce a su
+ * propia UI:
+ *
+ * - `{ kind: 'native', outcome: 'approved'|'pending'|'declined'|'cancelled' }`
+ *   — el flujo nativo terminó; en approved/pending/declined el user local ya
+ *   quedó sincronizado vía `updateUser` (el webhook del backend es la fuente
+ *   de verdad final, esto solo adelanta la UI).
+ * - `{ kind: 'browser' }` — fallback a la URL hospedada en el navegador:
+ *   backend sin `session_token` (despliegue anterior) o fallo recuperable del
+ *   SDK. El caller debe activar su re-check por AppState.
+ * - `{ kind: 'request-error', status, message }` — el POST falló; `status`
+ *   codifica el estado (409 en revisión, 403 rechazada, 400 ya verificada).
+ * - `{ kind: 'sdk-error', errorType, message }` — el SDK falló sin rescate
+ *   (p. ej. `cameraAccessDenied`: abrir el navegador no arregla un permiso
+ *   negado, mejor un mensaje accionable).
+ */
+const useKycVerification = () => {
+
+	const { updateUser } = useAuth()
+
+	// true mientras se pide la sesión o el flujo nativo está en pantalla
+	const [launching, setLaunching] = useState(false)
+
+	const launchKyc = useCallback(async () => {
+		setLaunching(true)
+		try {
+			const resp = await userApi.requestKYCSession()
+			if (!resp.success || !resp.data) {
+				return { kind: 'request-error', status: resp.status, message: resp.error }
+			}
+
+			// Con o sin SDK, arranca la gracia de 48h del banner del Home
+			markKycSessionStarted()
+
+			if (!resp.sessionToken) {
+				await Linking.openURL(resp.data)
+				return { kind: 'browser' }
+			}
+
+			const result = await startVerification(resp.sessionToken, {
+				languageCode: SDK_LANGUAGE[i18n.language] || i18n.language,
+				showCloseButton: true,
+				showExitConfirmation: true,
+				// El SDK se cierra solo al terminar: los estados de éxito/revisión
+				// los pinta la app con sus propias pantallas (lotties del theme)
+				closeOnComplete: true,
+			})
+
+			if (result.type === 'completed') {
+				const status = result.session?.status
+				if (status === VerificationStatus.Approved) {
+					// Adelanta badges/gates sin esperar al próximo /user/extended
+					updateUser({ kyc: true, kyc_status: 'approved' })
+					return { kind: 'native', outcome: 'approved' }
+				}
+				if (status === VerificationStatus.Declined) {
+					updateUser({ kyc_status: 'declined' })
+					return { kind: 'native', outcome: 'declined' }
+				}
+				updateUser({ kyc_status: 'pending' })
+				return { kind: 'native', outcome: 'pending' }
+			}
+
+			if (result.type === 'cancelled') return { kind: 'native', outcome: 'cancelled' }
+
+			// SDK falló: rescate por navegador salvo permiso de cámara negado
+			if (result.error?.type !== 'cameraAccessDenied') {
+				try {
+					await Linking.openURL(resp.data)
+					return { kind: 'browser' }
+				} catch { /* sin navegador tampoco: cae al sdk-error */ }
+			}
+			return { kind: 'sdk-error', errorType: result.error?.type, message: result.error?.message }
+
+		} catch (e) {
+			return { kind: 'sdk-error', message: e?.message }
+		} finally { setLaunching(false) }
+	}, [updateUser])
+
+	return { launchKyc, launching }
+}
+
+export default useKycVerification

--- a/hooks/useKycVerification.test.js
+++ b/hooks/useKycVerification.test.js
@@ -1,0 +1,123 @@
+/**
+ * Behavior tests del flujo de verificación de identidad nativo
+ * (useKycVerification): mapeo del resultado del SDK a los outcomes
+ * discriminados, sincronización optimista del user local, fallback a
+ * navegador cuando el backend no manda session_token o el SDK falla, y
+ * propagación de los códigos HTTP del POST /user/kyc — node environment
+ * con SDK/API/AuthContext/Linking mockeados.
+ * @jest-environment node
+ */
+jest.mock('react-native', () => ({ Linking: { openURL: jest.fn(async () => true) } }))
+jest.mock('../api/userApi', () => ({ userApi: { requestKYCSession: jest.fn() } }))
+jest.mock('../auth/AuthContext', () => ({ useAuth: jest.fn() }))
+jest.mock('./useKycPrompt', () => ({ markKycSessionStarted: jest.fn() }))
+
+import React from 'react'
+import { act, create } from 'react-test-renderer'
+import { Linking } from 'react-native'
+import { startVerification } from '@didit-protocol/sdk-react-native'
+import { userApi } from '../api/userApi'
+import { useAuth } from '../auth/AuthContext'
+import { markKycSessionStarted } from './useKycPrompt'
+import useKycVerification from './useKycVerification'
+
+const SESSION_URL = 'https://verify.didit.me/session/tok.en.jwt'
+
+let hookValue
+const Probe = () => {
+	hookValue = useKycVerification()
+	return null
+}
+
+const renderHook = async () => {
+	await act(async () => { create(<Probe />) })
+	return hookValue
+}
+
+const updateUser = jest.fn()
+
+beforeEach(() => {
+	jest.clearAllMocks()
+	useAuth.mockReturnValue({ updateUser })
+	userApi.requestKYCSession.mockResolvedValue({ success: true, data: SESSION_URL, sessionToken: 'tok.en.jwt', status: 200 })
+})
+
+const launch = async () => {
+	const value = await renderHook()
+	let result
+	await act(async () => { result = await value.launchKyc() })
+	return result
+}
+
+describe('flujo nativo', () => {
+	test('aprobada: sincroniza el user local y devuelve approved', async () => {
+		startVerification.mockResolvedValue({ type: 'completed', session: { sessionId: 's1', status: 'Approved' } })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'native', outcome: 'approved' })
+		expect(updateUser).toHaveBeenCalledWith({ kyc: true, kyc_status: 'approved' })
+		expect(markKycSessionStarted).toHaveBeenCalled()
+		expect(Linking.openURL).not.toHaveBeenCalled()
+	})
+
+	test('en revisión: marca pending sin tocar el flag kyc', async () => {
+		startVerification.mockResolvedValue({ type: 'completed', session: { sessionId: 's1', status: 'Pending' } })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'native', outcome: 'pending' })
+		expect(updateUser).toHaveBeenCalledWith({ kyc_status: 'pending' })
+	})
+
+	test('rechazada: marca declined', async () => {
+		startVerification.mockResolvedValue({ type: 'completed', session: { sessionId: 's1', status: 'Declined' } })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'native', outcome: 'declined' })
+		expect(updateUser).toHaveBeenCalledWith({ kyc_status: 'declined' })
+	})
+
+	test('cancelada por el usuario: sin efectos secundarios', async () => {
+		startVerification.mockResolvedValue({ type: 'cancelled' })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'native', outcome: 'cancelled' })
+		expect(updateUser).not.toHaveBeenCalled()
+	})
+})
+
+describe('fallback a navegador', () => {
+	test('backend sin session_token (despliegue anterior): abre la URL hospedada', async () => {
+		userApi.requestKYCSession.mockResolvedValue({ success: true, data: SESSION_URL, sessionToken: null, status: 200 })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'browser' })
+		expect(Linking.openURL).toHaveBeenCalledWith(SESSION_URL)
+		expect(startVerification).not.toHaveBeenCalled()
+		expect(markKycSessionStarted).toHaveBeenCalled()
+	})
+
+	test('el SDK falla por red: rescata por navegador en vez de dejar al usuario tirado', async () => {
+		startVerification.mockResolvedValue({ type: 'failed', error: { type: 'networkError', message: 'offline' } })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'browser' })
+		expect(Linking.openURL).toHaveBeenCalledWith(SESSION_URL)
+	})
+
+	test('permiso de cámara negado: NO rescata por navegador (mensaje accionable)', async () => {
+		startVerification.mockResolvedValue({ type: 'failed', error: { type: 'cameraAccessDenied', message: 'denied' } })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'sdk-error', errorType: 'cameraAccessDenied', message: 'denied' })
+		expect(Linking.openURL).not.toHaveBeenCalled()
+	})
+})
+
+describe('errores del POST /user/kyc', () => {
+	test('propaga status y mensaje sin lanzar el SDK', async () => {
+		userApi.requestKYCSession.mockResolvedValue({ success: false, status: 409, error: 'En revisión' })
+		const result = await launch()
+		expect(result).toEqual({ kind: 'request-error', status: 409, message: 'En revisión' })
+		expect(startVerification).not.toHaveBeenCalled()
+		expect(markKycSessionStarted).not.toHaveBeenCalled()
+	})
+
+	test('una excepción del SDK degrada a sdk-error, nunca revienta la pantalla', async () => {
+		startVerification.mockRejectedValue(new Error('native crash'))
+		const result = await launch()
+		expect(result).toEqual({ kind: 'sdk-error', message: 'native crash' })
+	})
+})

--- a/i18n/locales/en/auth.json
+++ b/i18n/locales/en/auth.json
@@ -120,7 +120,8 @@
 			"wrongCode": "Incorrect code",
 			"kycInReview": "Your verification is under review",
 			"kycStartFailed": "Couldn't start the verification",
-			"finishFailed": "Couldn't complete the registration, try again"
+			"finishFailed": "Couldn't complete the registration, try again",
+			"kycApproved": "Identity verified!"
 		}
 	},
 	"recoverPassword": {

--- a/i18n/locales/en/settings.json
+++ b/i18n/locales/en/settings.json
@@ -424,7 +424,9 @@
 			"inReview": "Your verification is under review",
 			"errorTitle": "Error",
 			"sessionFailed": "Couldn't get the verification session",
-			"genericError": "An error occurred"
+			"genericError": "An error occurred",
+			"approved": "Identity verified!",
+			"cameraDenied": "We need camera access to verify your identity. Enable it in your system settings."
 		},
 		"verified": {
 			"title": "Identity verified!",

--- a/i18n/locales/es/auth.json
+++ b/i18n/locales/es/auth.json
@@ -120,7 +120,8 @@
 			"wrongCode": "Código incorrecto",
 			"kycInReview": "Tu verificación está en revisión",
 			"kycStartFailed": "No se pudo iniciar la verificación",
-			"finishFailed": "No se pudo completar el registro, intenta de nuevo"
+			"finishFailed": "No se pudo completar el registro, intenta de nuevo",
+			"kycApproved": "¡Identidad verificada!"
 		}
 	},
 	"recoverPassword": {

--- a/i18n/locales/es/settings.json
+++ b/i18n/locales/es/settings.json
@@ -424,7 +424,9 @@
 			"inReview": "Tu verificación está en revisión",
 			"errorTitle": "Error",
 			"sessionFailed": "No se pudo obtener la sesión de verificación",
-			"genericError": "Ha ocurrido un error"
+			"genericError": "Ha ocurrido un error",
+			"approved": "¡Identidad verificada!",
+			"cameraDenied": "Necesitamos acceso a la cámara para verificar tu identidad. Actívalo en los ajustes del sistema."
 		},
 		"verified": {
 			"title": "¡Identidad verificada!",

--- a/i18n/locales/pt/auth.json
+++ b/i18n/locales/pt/auth.json
@@ -120,7 +120,8 @@
 			"wrongCode": "Código incorreto",
 			"kycInReview": "Sua verificação está em análise",
 			"kycStartFailed": "Não foi possível iniciar a verificação",
-			"finishFailed": "Não foi possível concluir o cadastro, tente de novo"
+			"finishFailed": "Não foi possível concluir o cadastro, tente de novo",
+			"kycApproved": "Identidade verificada!"
 		}
 	},
 	"recoverPassword": {

--- a/i18n/locales/pt/settings.json
+++ b/i18n/locales/pt/settings.json
@@ -424,7 +424,9 @@
 			"inReview": "Sua verificação está em análise",
 			"errorTitle": "Erro",
 			"sessionFailed": "Não foi possível obter a sessão de verificação",
-			"genericError": "Ocorreu um erro"
+			"genericError": "Ocorreu um erro",
+			"approved": "Identidade verificada!",
+			"cameraDenied": "Precisamos de acesso à câmera para verificar sua identidade. Ative-o nos ajustes do sistema."
 		},
 		"verified": {
 			"title": "Identidade verificada!",

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -10,6 +10,11 @@ require Pod::Executable.execute_command('node', ['-p',
 # requires iOS 15.5 for spec resolution.
 platform :ios, '15.5'
 
+# Didit KYC nativo: variante 'autodetection' (captura automática de documento/cara,
+# SIN NFC — NFC exigiría entitlement + capability en el provisioning profile).
+# El wrapper RN (@didit-protocol/sdk-react-native) lee esta global en su podspec.
+$DiditSdkIosVariant = 'autodetection'
+
 # Compilar React core y dependencias desde fuente. El core precompilado de RN 0.84
 # (React-Core-prebuilt) se construye como release (sin REACT_NATIVE_DEBUG), con un
 # layout de Props/Sealable distinto al del código Fabric de terceros compilado en
@@ -26,6 +31,10 @@ use_frameworks! :linkage => :static
 
 target 'QvaPay' do
   config = use_native_modules!
+
+  # DiditSDK no está en el trunk de CocoaPods: se resuelve por podspec remoto,
+  # pineado a la versión nativa que empaqueta el wrapper RN (4.7.2).
+  pod 'DiditSDK/AutoDetection', :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.7.2/DiditSDK.podspec'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -30,6 +30,7 @@ PODS:
   - boost (1.84.0)
   - BVLinearGradient (2.8.3):
     - React-Core
+  - DiditSDK/AutoDetection (4.7.2)
   - DoubleConversion (1.1.6)
   - fast_float (8.0.0)
   - FBLazyVector (0.84.1)
@@ -3545,6 +3546,35 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - SdkReactNative (4.7.3):
+    - boost
+    - DiditSDK/AutoDetection (= 4.7.2)
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -3755,6 +3785,7 @@ DEPENDENCIES:
   - "AsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
+  - DiditSDK/AutoDetection (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.7.2/DiditSDK.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -3859,6 +3890,7 @@ DEPENDENCIES:
   - RNSound (from `../node_modules/react-native-sound`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNWorklets (from `../node_modules/react-native-worklets`)
+  - "SdkReactNative (from `../node_modules/@didit-protocol/sdk-react-native`)"
   - SocketRocket (~> 0.7.1)
   - "stripe-react-native (from `../node_modules/@stripe/stripe-react-native`)"
   - VisionCamera (from `../node_modules/react-native-vision-camera`)
@@ -3907,6 +3939,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   BVLinearGradient:
     :path: "../node_modules/react-native-linear-gradient"
+  DiditSDK:
+    :podspec: https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.7.2/DiditSDK.podspec
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   fast_float:
@@ -4114,6 +4148,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-svg"
   RNWorklets:
     :path: "../node_modules/react-native-worklets"
+  SdkReactNative:
+    :path: "../node_modules/@didit-protocol/sdk-react-native"
   stripe-react-native:
     :path: "../node_modules/@stripe/stripe-react-native"
   VisionCamera:
@@ -4127,6 +4163,7 @@ SPEC CHECKSUMS:
   AsyncStorage: d7dcc63ec84ccd43e489b5dcdbd4bf93d12f04eb
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
+  DiditSDK: d190e09da2e7c5bf663244c19ea5583a826ccd7c
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: baf9d0492aa305444465c798e972f87e6a60dc69
@@ -4247,6 +4284,7 @@ SPEC CHECKSUMS:
   RNSound: 80f864773ff8f670fc8f052a3e478cec201d9b43
   RNSVG: a14f58a6be359fd52b3d6eef86c1a6461264dd78
   RNWorklets: 16432d8c65c186246eb2761e9d30373dd17f2ffc
+  SdkReactNative: 0784b1e2ff48e4e2f9cc91dd624e7aeb7590194a
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
@@ -4267,6 +4305,6 @@ SPEC CHECKSUMS:
   VisionCameraBarcodeScanner: 64a1d69adfe42b51f618649ee7a6617b1c3e25ad
   Yoga: 9e495ad6f457c4ff504a8328981496b5cf41dd7f
 
-PODFILE CHECKSUM: 58028f42af9ee6f1394adb81af86e462a10d2a8d
+PODFILE CHECKSUM: e93be018783276bd136a84c4f3e400d23d04e5c1
 
 COCOAPODS: 1.16.2

--- a/ios/QvaPay/Info.plist
+++ b/ios/QvaPay/Info.plist
@@ -84,7 +84,9 @@
 		<string>_qvapay-nearby._udp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>Para poder escanear QRs, $(PRODUCT_NAME) necesita permiso.</string>
+	<string>QvaPay usa la cámara para escanear QRs y para capturar tu documento y rostro durante la verificación de identidad.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>QvaPay usa el micrófono para grabar el video de prueba de vida durante la verificación de identidad.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>QvaPay necesita acceso a tus contactos para encontrar amigos que ya usan la app y facilitar los envios de dinero.</string>
 	<key>NSFaceIDUsageDescription</key>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -7,3 +7,16 @@
  * instancia global), dejando intactos los harnesses `create(<Componente/>)`.
  */
 require('./i18n')
+
+/**
+ * El SDK nativo de verificación de identidad es un TurboModule: importarlo en
+ * el entorno node de jest lanzaría al registrar el módulo nativo. Mock global
+ * con la misma superficie que consume useKycVerification; las suites que
+ * necesiten resultados concretos lo re-mockean con jest.mocked/mockResolvedValue.
+ */
+/* global jest */
+jest.mock('@didit-protocol/sdk-react-native', () => ({
+	startVerification: jest.fn(async () => ({ type: 'cancelled' })),
+	startVerificationWithWorkflow: jest.fn(async () => ({ type: 'cancelled' })),
+	VerificationStatus: { Approved: 'Approved', Pending: 'Pending', Declined: 'Declined' },
+}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "QvaPay",
-  "version": "2.3.16",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "QvaPay",
-      "version": "2.3.16",
+      "version": "2.4.1",
       "dependencies": {
         "@adrianso/react-native-device-brightness": "^1.2.7",
         "@d11/react-native-fast-image": "^8.13.0",
+        "@didit-protocol/sdk-react-native": "^4.7.3",
         "@klarna/react-native-vector-drawable": "^0.5.1",
         "@react-native-async-storage/async-storage": "^3.1.1",
         "@react-native-clipboard/clipboard": "^1.16.3",
@@ -2140,6 +2141,26 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@didit-protocol/sdk-react-native": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@didit-protocol/sdk-react-native/-/sdk-react-native-4.7.3.tgz",
+      "integrity": "sha512-pzBTRobhvG1YJmfW2qMAtFLS7/3ERF6RbFhRhMy1sQp/xD7lix1MMAqUJIakghLQ+r/Q+n2dpe/zDRePyvJncA==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "example-expo"
+      ],
+      "peerDependencies": {
+        "@expo/config-plugins": ">=7.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@expo/config-plugins": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@d11/react-native-fast-image": "^8.13.0",
+    "@didit-protocol/sdk-react-native": "^4.7.3",
     "@klarna/react-native-vector-drawable": "^0.5.1",
     "@react-native-async-storage/async-storage": "^3.1.1",
     "@react-native-clipboard/clipboard": "^1.16.3",

--- a/screens/settings/subpanels/KYC.jsx
+++ b/screens/settings/subpanels/KYC.jsx
@@ -13,8 +13,8 @@ import QPLoader from '../../../ui/particles/QPLoader'
 // API
 import { userApi } from '../../../api/userApi'
 
-// Nudge de KYC (gracia post-sesión para el banner del Home)
-import { markKycSessionStarted } from '../../../hooks/useKycPrompt'
+// Flujo de verificación nativo (SDK embebido, con fallback a navegador)
+import useKycVerification from '../../../hooks/useKycVerification'
 
 // Lottie
 import LottieView from 'lottie-react-native'
@@ -38,16 +38,16 @@ const PENDING_POLL_MS = 12000
  * `GET /user/kyc` → `{ kyc, kyc_status: none|pending|approved|declined }`:
  *
  * - `verified`  — kyc true: Lottie de verificado.
- * - `pending`   — Didit en revisión: sin CTA, polling cada 12s.
+ * - `pending`   — verificación en revisión: sin CTA, polling cada 12s.
  * - `declined`  — rechazada: caso de soporte, sin re-intento self-service
  *                 (el backend responde 403 a nuevas sesiones).
- * - `idle`      — sin verificar: beneficios + CTA que abre la URL hospedada
- *                 de Didit en el navegador (`POST /user/kyc`).
+ * - `idle`      — sin verificar: beneficios + CTA que lanza el flujo NATIVO
+ *                 de verificación (useKycVerification) sin salir de la app.
  *
- * Al volver del navegador (AppState → active tras abrir la sesión) se
- * re-consulta el estado — espejo del recheck por `visibilitychange` de la web.
- * Los códigos del POST se mapean: 409 → pending, 403 → declined/max intentos,
- * 400 → ya verificado (refresca).
+ * El flujo nativo devuelve el resultado en línea (approved/pending/declined →
+ * transición de estado inmediata). Solo en el fallback a navegador (backend
+ * viejo sin session_token) sobrevive el re-check por AppState al volver, y los
+ * códigos del POST se mapean: 409 → pending, 403 → declined, 400 → refresca.
  */
 const KYC = () => {
 
@@ -62,9 +62,11 @@ const KYC = () => {
 	// Auth
 	const { user, updateUser } = useAuth()
 
+	// Flujo de verificación nativo
+	const { launchKyc, launching } = useKycVerification()
+
 	// States: 'loading' | 'verified' | 'pending' | 'declined' | 'idle'
 	const [status, setStatus] = useState('loading')
-	const [requesting, setRequesting] = useState(false)
 	const sessionOpenedRef = useRef(false)
 
 	const checkStatus = useCallback(async () => {
@@ -94,7 +96,7 @@ const KYC = () => {
 	// Estado inicial
 	useEffect(() => { checkStatus() }, [checkStatus])
 
-	// Re-check al volver del navegador de Didit
+	// Re-check al volver del navegador (solo aplica al fallback sin SDK)
 	useEffect(() => {
 		const sub = AppState.addEventListener('change', (state) => {
 			if (state === 'active' && sessionOpenedRef.current) {
@@ -111,17 +113,31 @@ const KYC = () => {
 		return () => clearInterval(poll)
 	}, [status, checkStatus])
 
-	// Request verification session URL and open in browser
+	// Lanza el flujo nativo y traduce su resultado al estado de la pantalla
 	const requestVerification = useCallback(async () => {
-		try {
-			setRequesting(true)
-			const resp = await userApi.requestKYCSession()
-			if (resp.success && resp.data) {
-				sessionOpenedRef.current = true
-				markKycSessionStarted()
-				await Linking.openURL(resp.data)
-				return
+		const resp = await launchKyc()
+
+		if (resp.kind === 'native') {
+			if (resp.outcome === 'approved') {
+				setStatus('verified')
+				toast.success(t('settings.kyc.toasts.approved'))
+			} else if (resp.outcome === 'pending') {
+				setStatus('pending')
+				toast.info(t('settings.kyc.toasts.inReview'))
+			} else if (resp.outcome === 'declined') {
+				setStatus('declined')
 			}
+			// cancelled: el usuario cerró el flujo, se queda en idle sin ruido
+			return
+		}
+
+		if (resp.kind === 'browser') {
+			// Fallback a la URL hospedada: el resultado llega al volver (AppState)
+			sessionOpenedRef.current = true
+			return
+		}
+
+		if (resp.kind === 'request-error') {
 			// El backend codifica el estado en el status HTTP
 			if (resp.status === 409) {
 				setStatus('pending')
@@ -131,11 +147,18 @@ const KYC = () => {
 			} else if (resp.status === 400) {
 				checkStatus()
 			} else {
-				toast.error(t('settings.kyc.toasts.errorTitle'), { description: resp.error || t('settings.kyc.toasts.sessionFailed') })
+				toast.error(t('settings.kyc.toasts.errorTitle'), { description: resp.message || t('settings.kyc.toasts.sessionFailed') })
 			}
-		} catch (e) { toast.error(t('settings.kyc.toasts.errorTitle'), { description: e.message || t('settings.kyc.toasts.genericError') }) }
-		finally { setRequesting(false) }
-	}, [checkStatus, t])
+			return
+		}
+
+		// sdk-error
+		if (resp.errorType === 'cameraAccessDenied') {
+			toast.error(t('settings.kyc.toasts.errorTitle'), { description: t('settings.kyc.toasts.cameraDenied') })
+		} else {
+			toast.error(t('settings.kyc.toasts.errorTitle'), { description: resp.message || t('settings.kyc.toasts.genericError') })
+		}
+	}, [launchKyc, checkStatus, t])
 
 	if (status === 'loading') return <QPLoader />
 
@@ -212,9 +235,9 @@ const KYC = () => {
 
 			<View style={containerStyles.bottomButtonContainer}>
 				<QPButton
-					title={requesting ? t('settings.kyc.idle.opening') : t('settings.kyc.idle.verifyButton')}
+					title={launching ? t('settings.kyc.idle.opening') : t('settings.kyc.idle.verifyButton')}
 					onPress={requestVerification}
-					loading={requesting}
+					loading={launching}
 					textStyle={{ color: theme.colors.almostWhite }}
 				/>
 			</View>


### PR DESCRIPTION
## Summary

The KYC flow no longer sends users to the browser: the identity provider's **native SDK** (autodetection variant — automatic document + liveness capture, no NFC) runs the whole verification **inside the app**, in the user's language (es/en/pt-BR), with the app's own success/pending screens.

## How it works

- **`hooks/useKycVerification`** is the single launch point (Settings KYC screen + Register wizard). It requests the session, launches the native flow with the backend's `session_token`, and returns a discriminated result:
  - `native approved/pending/declined` → optimistic `updateUser` sync (webhook stays the source of truth) and instant UI transition
  - `browser` → graceful fallback to the hosted URL when the backend doesn't send `session_token` yet (older deploy) or the SDK fails recoverably — the old AppState re-check path survives only here
  - `request-error` → the HTTP status mapping (409 in review / 403 declined / 400 already verified) is preserved
  - camera permission denied gets an actionable message instead of a pointless browser fallback
- **Register wizard**: approved/in-review auto-advances the step; cancelling keeps "Ahora no" available

## Native wiring

- iOS: `DiditSDK/AutoDetection` 4.7.2 via remote podspec, new mic usage description, broadened camera copy
- Android: scoped `me.didit` Maven repo, `diditSdkAndroidVariant=autodetection`, R8 keeps, and an exclusion of the duplicate `com.caverock:androidsvg` jar (fast-image) in favor of the `-aar` the SDK brings — fixes `checkDuplicateClasses`

## Backend dependency

Pairs with the qpweb change that returns `session_token` alongside the hosted URL. **Not required to ship** — without it the app falls back to the browser flow transparently.

## Testing

- 1,695 tests green (11 new: 9 for the hook, 2 for the API contract), lint 0 errors, i18n parity checks OK
- `assembleDebug` builds end-to-end with the SDK integrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compliance-critical onboarding (KYC) with a new native SDK, optimistic client-side status, and camera/microphone permissions; mitigated by browser fallback, preserved HTTP error mapping, and automated tests.
> 
> **Overview**
> **KYC now runs in-app** via the Didit React Native SDK (autodetection: document + liveness, no NFC) instead of always opening the hosted URL in the browser. A shared **`useKycVerification`** hook requests `POST /user/kyc`, starts native verification when the backend returns **`session_token`**, maps SDK outcomes to discriminated results (`native` / `browser` / `request-error` / `sdk-error`), and **optimistically updates** local `kyc` / `kyc_status` on completion. **Register** and **Settings → KYC** both call `launchKyc`; browser fallback and AppState re-check remain when there is no token or the SDK fails recoverably (camera denied gets a dedicated toast, not a browser redirect).
> 
> **Platform wiring:** `@didit-protocol/sdk-react-native` (app **2.4.1**), iOS `DiditSDK/AutoDetection` pod + camera/mic usage strings, Android scoped Maven repo, `diditSdkAndroidVariant=autodetection`, R8 keeps for `me.didit.**`, and Gradle exclusion of duplicate `androidsvg` jar. **`userApi.requestKYCSession`** now surfaces `sessionToken`; Jest mocks the SDK globally plus new hook/API tests. README copy de-emphasizes vendor names (Stripe/Didit/Zendit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799b0ca4e0e99b973acc90765d4cb3bb3f6eec7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->