### PR TITLE
fix(biometrics): add Xiaomi/MIUI fallback for fingerprint detection

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -203,6 +203,7 @@ export const getSupportedBiometryType = async () => {
 		const type = await Keychain.getSupportedBiometryType()
 		return type // 'FaceID', 'TouchID', 'Fingerprint', or null
 	} catch (error) {
+		console.warn('[biometrics] getSupportedBiometryType failed:', error instanceof Error ? error.message : error)
 		return null
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "QvaPay",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "QvaPay",
-      "version": "2.5.0",
+      "version": "2.5.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@adrianso/react-native-device-brightness": "^1.2.7",
         "@d11/react-native-fast-image": "^8.13.0",
@@ -45,7 +46,7 @@
         "react-native-image-picker": "^8.2.1",
         "react-native-in-app-review": "^4.4.2",
         "react-native-international-phone-number": "^0.11.10",
-        "react-native-keychain": "^10.0.0",
+        "react-native-keychain": "10.0.0",
         "react-native-linear-gradient": "^2.8.3",
         "react-native-nitro-image": "^0.15.0",
         "react-native-nitro-modules": "^0.35.9",
@@ -92,6 +93,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-native": "^5.0.0",
         "jest": "^30.4.2",
+        "patch-package": "^8.0.1",
         "prettier": "^3.8.3",
         "react-doctor": "^0.9.6",
         "react-native-svg-transformer": "^1.5.3",
@@ -6677,6 +6679,13 @@
         "node": ">=14.6"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -10233,6 +10242,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -12711,6 +12730,26 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12747,6 +12786,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -12771,6 +12820,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -14327,6 +14386,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -15093,6 +15162,143 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/path-dirname": {
@@ -18669,6 +18875,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -19704,3 +19920,4 @@
     }
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"preios:device": "node scripts/sync-version.js",
 		"preios:build": "node scripts/sync-version.js",
 		"preandroid": "node scripts/sync-version.js",
-		"doctor": "npx react-doctor@latest"
+		"doctor": "npx react-doctor@latest",
+		"postinstall": "patch-package --error-on-fail"
 	},
 	"dependencies": {
 		"@adrianso/react-native-device-brightness": "^1.2.7",
@@ -66,7 +67,7 @@
 		"react-native-image-picker": "^8.2.1",
 		"react-native-in-app-review": "^4.4.2",
 		"react-native-international-phone-number": "^0.11.10",
-		"react-native-keychain": "^10.0.0",
+		"react-native-keychain": "10.0.0",
 		"react-native-linear-gradient": "^2.8.3",
 		"react-native-nitro-image": "^0.15.0",
 		"react-native-nitro-modules": "^0.35.9",
@@ -113,6 +114,7 @@
 		"eslint-plugin-react-hooks": "^7.1.1",
 		"eslint-plugin-react-native": "^5.0.0",
 		"jest": "^30.4.2",
+		"patch-package": "^8.0.1",
 		"prettier": "^3.8.3",
 		"react-doctor": "^0.9.6",
 		"react-native-svg-transformer": "^1.5.3",

--- a/patches/react-native-keychain+10.0.0.patch
+++ b/patches/react-native-keychain+10.0.0.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/DeviceAvailability.kt b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/DeviceAvailability.kt
+index a4e7b3d..7e1badf 100644
+--- a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/DeviceAvailability.kt
++++ b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/DeviceAvailability.kt
+@@ -23,9 +23,29 @@ object DeviceAvailability {
+   }
+ 
+   fun isStrongBiometricAuthAvailable(context: Context): Boolean {
+-    return BiometricManager.from(context)
+-      .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
+-      BiometricManager.BIOMETRIC_SUCCESS
++    if (BiometricManager.from(context)
++            .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
++        BiometricManager.BIOMETRIC_SUCCESS
++    ) {
++      return true
++    }
++
++    // Fallback for Xiaomi/MIUI where BiometricManager.canAuthenticate(BIOMETRIC_STRONG)
++    // is known to return false positives (error 12 or -1) even when fingerprint hardware
++    // is present and enrolled. MIUI implements the deprecated FingerprintManager correctly,
++    // so we check it directly on devices manufactured by Xiaomi (covers Xiaomi, Redmi and POCO).
++    if (Build.MANUFACTURER.equals("xiaomi", ignoreCase = true)) {
++      if (!isFingerprintAuthAvailable(context)) return false
++      return try {
++        @Suppress("DEPRECATION")
++        val fm = context.getSystemService(Context.FINGERPRINT_SERVICE)
++          as? android.hardware.fingerprint.FingerprintManager
++        fm?.hasEnrolledFingerprints() == true
++      } catch (e: Exception) {
++        false
++      }
++    }
++    return false
+   }
+ 
+   fun isDevicePasscodeAvailable(context: Context): Boolean {


### PR DESCRIPTION
## Summary

Fixes fingerprint detection on Xiaomi/Redmi devices where `BiometricManager.canAuthenticate(BIOMETRIC_STRONG)` returns false positives due to MIUI's custom implementation.

Closes #37

## Changes

- **`patches/react-native-keychain+10.0.0.patch`** — Patches `DeviceAvailability.kt` to add a Xiaomi/MIUI fallback that checks `FingerprintManager.hasEnrolledFingerprints()` directly when `BiometricManager` fails on `xiaomi`/`redmi` branded devices
- **`api/client.ts`** — Adds `console.warn` logging to `getSupportedBiometryType()` catch block for debugging on affected devices
- **`package.json`** — Adds `patch-package` devDependency + `postinstall` script so the patch survives `npm install`

## Root Cause

`react-native-keychain` v10.0.0 uses `androidx.biometric.BiometricManager.canAuthenticate(BIOMETRIC_STRONG)` which on MIUI returns error 12 or -1 even when fingerprint hardware is present and enrolled. The library has no Xiaomi workaround (only OnePlus in `ResultHandlerProvider.kt`), and the deprecated `FingerprintManager` API — which MIUI implements correctly — is never consulted.

## Testing

Verified on **Xiaomi Redmi Note 9** (MTK Helio G85, **Android 10**, MIUI 12), app version **2.4.1**:
- Built a release APK from the `fix/xiaomi-biometrics` branch via CI `workflow_dispatch`
- Sideloaded on the affected device
- Biometric enrollment prompt appears after first login
- Settings > Biometrics shows fingerprint as active
- Biometric login button appears on Login screen
- Biometric login works correctly

## Why patch-package

Upgrading `androidx.biometric` to 1.2.0+ would fix this upstream, but that lives inside `react-native-keychain`'s native build. Using `patch-package` is the least invasive approach that doesn't require forking the library.