### PR TITLE
fix(lock): las cajas del PIN ya no colapsan a rayas verticales

### DIFF
--- a/lock/LockScreen.tsx
+++ b/lock/LockScreen.tsx
@@ -236,8 +236,13 @@ const styles = StyleSheet.create({
 		flex: 1,
 		height: 1,
 	},
+	// El contenedor padre centra en el eje horizontal (alignItems: 'center'), así que
+	// sin un ancho propio esta fila se encogería al contenido y las cajas `flex: 1` de
+	// QPCodeInput colapsarían a rayas verticales
 	pinContainer: {
 		marginTop: 24,
+		width: '100%',
+		maxWidth: 280,
 	},
 })
 

--- a/ui/particles/QPCodeInput.test.js
+++ b/ui/particles/QPCodeInput.test.js
@@ -5,7 +5,7 @@
  * mock.contexts (the `this` of each call identifies which box was focused).
  * @jest-environment node
  */
-import { TextInput } from 'react-native'
+import { StyleSheet, TextInput } from 'react-native'
 import { act, create } from 'react-test-renderer'
 
 jest.mock('../../theme/ThemeContext', () => {
@@ -122,5 +122,19 @@ describe('QPCodeInput', () => {
 		focusMock.mockClear()
 		await act(async () => { ref.current.focus(2) })
 		expect(focusedBoxes()).toContain(getBoxes(tree)[2].instance)
+	})
+
+	// Regresión: las cajas son `flex: 1`, cuya base es el contenido. Bajo un padre que
+	// centre en horizontal (LockScreen) la fila se encoge y sin `minWidth` cada caja
+	// vacía queda del ancho del placeholder — el PIN se ve como cuatro rayas
+	test('every box keeps a minimum width so it cannot collapse to a stripe', async () => {
+		const four = await render()
+		for (const box of getBoxes(four)) {
+			expect(StyleSheet.flatten(box.props.style).minWidth).toBeGreaterThan(0)
+		}
+		const six = await render({ length: 6 })
+		for (const box of getBoxes(six)) {
+			expect(StyleSheet.flatten(box.props.style).minWidth).toBeGreaterThan(0)
+		}
 	})
 })

--- a/ui/particles/QPCodeInput.tsx
+++ b/ui/particles/QPCodeInput.tsx
@@ -148,14 +148,19 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		gap: 8,
 	},
+	// `flex: 1` reparte el ancho disponible, pero su base es el contenido: dentro de un
+	// padre encogido (uno que centre en el eje horizontal) una caja vacía mediría lo que
+	// ocupa el placeholder. `minWidth` es el suelo que evita ese colapso a rayas
 	box: {
 		flex: 1,
+		minWidth: 44,
 		height: 60,
 		borderRadius: 12,
 		textAlign: 'center',
 	},
 	boxSmall: {
 		flex: 1,
+		minWidth: 32,
 		height: 52,
 		borderRadius: 10,
 		textAlign: 'center',


### PR DESCRIPTION
Cierra #29.

## El problema

En `LockScreen` las cuatro cajas del PIN se ven como rayas verticales finas en vez de cuadrados. Reportado en 2.3.10 sobre Redmi Note 13 / Android 15 y confirmado sobre Samsung A21s, pero no es específico de ningún dispositivo: es determinista.

<img width="288" alt="Rayas verticales en vez de cajas" src="https://github.com/user-attachments/assets/e6e18cea-325e-40ef-910c-e5bbc2869160" />

## La causa

`styles.container` de `LockScreen` centra en horizontal (`alignItems: 'center'`), así que `pinContainer` no se estira: Yoga le da el ancho de su contenido. Las cajas de `QPCodeInput` son `flex: 1`, cuya base (`flexBasis: auto`) es el contenido — y el contenido de un `TextInput` vacío es el placeholder `·`. Resultado: cuatro cajas de ~8px de ancho y 60px de alto.

El resto de superficies con grid de PIN (SendConfirm, Withdraw, 2FA del login, AppLock, Register) envuelven el `QPCodeInput` en una columna con el `alignItems: stretch` por defecto, por eso allí nunca se vio.

La regresión entró en bd16262 (2026-02-26, v1.3.1), donde el `pinInput` de `LockScreen` pasó de `width: 60` a `flex: 1`. Cuando el grid se extrajo a `QPCodeInput` en la 2.0.5, ese `flex: 1` se heredó tal cual. Lleva roto desde febrero; se nota ahora porque el App Lock es opt-in.

## El arreglo

- `lock/LockScreen.tsx` — `pinContainer` recibe ancho propio: `width: '100%'` acotado con `maxWidth: 280` para que las cajas no se estiren de más en pantallas anchas (quedan en ~64px, cerca de los 60px del diseño original).
- `ui/particles/QPCodeInput.tsx` — `minWidth` en `box` (44) y `boxSmall` (32) como red de seguridad: ningún padre encogido puede volver a colapsarlas. Los valores dejan margen incluso en el peor caso (6 cajas en una pantalla de 320dp).

## Verificación

- Test de regresión en `QPCodeInput.test.js` que afirma el suelo de ancho en las 4 y las 6 cajas. Comprobado que falla si se quita el `minWidth`.
- `npm run typecheck` limpio, `npx eslint` sobre los archivos tocados sin errores nuevos, `npm test` en verde (1696 tests).

No he podido probarlo sobre un dispositivo físico — el cambio es puramente de layout y está cubierto por el test, pero conviene una pasada visual sobre el LockScreen antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only changes to the lock screen and shared OTP component, covered by a new regression test with no auth or data-handling impact.
> 
> **Overview**
> Fixes **LockScreen** PIN entry where four `QPCodeInput` boxes rendered as thin vertical stripes instead of square cells. The parent uses horizontal centering, so the PIN row shrank to placeholder width while each box used `flex: 1` with content-based flex basis.
> 
> **`LockScreen`** gives `pinContainer` `width: '100%'` and `maxWidth: 280` so the digit row has real horizontal space and boxes stay near the intended ~60px size on wide screens.
> 
> **`QPCodeInput`** adds `minWidth` on normal (`44`) and compact (`32`) boxes so empty inputs cannot collapse under any shrink-wrapped parent—not only the lock screen.
> 
> A **regression test** asserts every rendered box exposes a positive `minWidth` for 4- and 6-digit lengths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798f799e88b9b94677a24c7c8ee9d944f7e75de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->