### PR TITLE
fix(p2p): Best Rate ordena por conveniencia real y el switch deja de ser opcional

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
 	"name": "QvaPay",
 	"displayName": "QvaPay",
-	"version": "2.4.2",
-	"versionCode": 2402
+	"version": "2.4.3",
+	"versionCode": 2403
 }

--- a/ios/QvaPay.xcodeproj/project.pbxproj
+++ b/ios/QvaPay.xcodeproj/project.pbxproj
@@ -469,7 +469,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPay/QvaPay.entitlements;
-				CURRENT_PROJECT_VERSION = 2402;
+				CURRENT_PROJECT_VERSION = 2403;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				ENABLE_BITCODE = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -481,7 +481,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -507,7 +507,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPay/QvaPay.entitlements;
-				CURRENT_PROJECT_VERSION = 2402;
+				CURRENT_PROJECT_VERSION = 2403;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = QvaPay/Info.plist;
@@ -518,7 +518,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -760,7 +760,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPayWidgets/QvaPayWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2402;
+				CURRENT_PROJECT_VERSION = 2403;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = QvaPayWidgets/Info.plist;
@@ -772,7 +772,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.qvapay.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -791,7 +791,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = QvaPayWidgets/QvaPayWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2402;
+				CURRENT_PROJECT_VERSION = 2403;
 				DEVELOPMENT_TEAM = CN9WDS6BJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = QvaPayWidgets/Info.plist;
@@ -803,7 +803,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.qvapay.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "QvaPay",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"private": true,
 	"scripts": {
 		"android": "react-native run-android --main-activity .MainActivity",

--- a/screens/p2p/P2P.tsx
+++ b/screens/p2p/P2P.tsx
@@ -21,7 +21,7 @@ import QPSwitch from "../../ui/particles/QPSwitch"
 import P2PRequirementsGate from "./P2PRequirementsGate"
 import P2PFilterBar from "./P2PFilterBar"
 import P2PFiltersModal from "./P2PFiltersModal"
-import useP2PFilters from "./useP2PFilters"
+import useP2PFilters, { SORT_OPTIONS } from "./useP2PFilters"
 import useP2POffers from "./useP2POffers"
 
 // Icons
@@ -165,13 +165,44 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 	// se cierra, porque dos modales a la vez dan problemas): se anota para
 	// devolver al usuario donde estaba, elija moneda o descarte
 	const returnToFiltersRef = useRef(false)
+	// "Mejor tasa" solo existe con una moneda elegida (los ratios de monedas
+	// distintas no son comparables): elegirlo sin moneda abre el picker y deja el
+	// orden anotado para aplicarlo en cuanto se elija una. Descartar el picker
+	// cancela el orden en vez de dejarlo pedido y sin efecto.
+	const pendingSortRef = useRef<number | null>(null)
 	const closeCoinPicker = useCallback(() => {
 		setShowCoinPicker(false)
+		pendingSortRef.current = null
 		if (returnToFiltersRef.current) {
 			returnToFiltersRef.current = false
 			setShowFiltersModal(true)
 		}
 	}, [])
+
+	const handleSelectCoin = useCallback((coin: Coin) => {
+		setFilter("selectedCoin", coin)
+		// Se lee ANTES de cerrar: closeCoinPicker limpia el pendiente
+		const pendingSort = pendingSortRef.current
+		if (pendingSort != null) { setFilter("sortIndex", pendingSort) }
+		closeCoinPicker()
+	}, [setFilter, closeCoinPicker])
+
+	const handleSelectSort = useCallback((index: number) => {
+		setShowSortMenu(false)
+		if (SORT_OPTIONS[index]?.requiresCoin && !selectedCoin?.tick) {
+			pendingSortRef.current = index
+			setShowCoinPicker(true)
+			return
+		}
+		setFilter("sortIndex", index)
+	}, [selectedCoin?.tick, setFilter])
+
+	// Quitar la moneda deja sin sentido un orden que la exige: se vuelve al de
+	// por defecto en vez de dejar un badge de orden que no se está aplicando
+	const handleClearCoin = useCallback(() => {
+		setFilter("selectedCoin", null)
+		if (SORT_OPTIONS[sortIndex]?.requiresCoin) { setFilter("sortIndex", 0) }
+	}, [sortIndex, setFilter])
 
 	// Track P2P offer users for online status
 	useEffect(() => {
@@ -276,8 +307,10 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 			headerTitle: () => (
 				<View style={styles.headerSwitchWrap}>
 					<QPSwitch
-						value={typeFilter === "sell" ? "left" : typeFilter === "buy" ? "right" : null}
-						onChange={(side) => setFilter("typeFilter", side === "left" ? "sell" : side === "right" ? "buy" : null)}
+						value={typeFilter === "sell" ? "left" : "right"}
+						/* El lado del mercado es un modo, no un filtro: volver a tocar
+						   el lado activo (QPSwitch responde con null) no lo apaga */
+						onChange={(side) => { if (side) { setFilter("typeFilter", side === "left" ? "sell" : "buy") } }}
 						leftText={t('p2p.common.buy')}
 						rightText={t('p2p.common.sell')}
 						leftColor={theme.colors.danger}
@@ -335,9 +368,9 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 					showSortMenu={showSortMenu}
 					activeFilterBadges={activeFilterBadges}
 					onOpenCoinPicker={() => setShowCoinPicker(true)}
-					onClearCoin={() => setFilter("selectedCoin", null)}
+					onClearCoin={handleClearCoin}
 					onToggleSortMenu={() => setShowSortMenu(!showSortMenu)}
-					onSelectSort={(idx: number) => { setFilter("sortIndex", idx); setShowSortMenu(false) }}
+					onSelectSort={handleSelectSort}
 					onClearSort={() => setFilter("sortIndex", 0)}
 					onRemoveBadge={handleRemoveBadge}
 					theme={theme}
@@ -387,7 +420,7 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 			<QPCoinPicker
 				visible={showCoinPicker}
 				onClose={closeCoinPicker}
-				onSelect={(coin) => { setFilter("selectedCoin", coin); closeCoinPicker() }}
+				onSelect={handleSelectCoin}
 				coins={availableCoins}
 				/* El filtro guarda una moneda SINTÉTICA cuando llega por route.params
 				   (solo tick/name/logo): el picker la tipa como Coin completa */

--- a/screens/p2p/P2PFilterBar.tsx
+++ b/screens/p2p/P2PFilterBar.tsx
@@ -61,11 +61,19 @@ const P2PFilterBar = ({ selectedCoin, sortIndex, showSortMenu, activeFilterBadge
 			{/* Sort Menu */}
 			{showSortMenu && (
 				<View style={styles.activeBadgesBar}>
-					{SORT_OPTIONS.map((option, idx) => (
-						<Pressable key={option.labelKey} style={[styles.activeBadge, { backgroundColor: sortIndex === idx ? theme.colors.primary : theme.colors.surface, borderWidth: 0.5, borderColor: theme.colors.border }]} onPress={() => onSelectSort(idx)}>
-							<Text style={[textStyles.caption, { color: sortIndex === idx ? theme.colors.almostWhite : theme.colors.primaryText, fontSize: theme.typography.fontSize.xs }]}>{t(option.labelKey)}</Text>
-						</Pressable>
-					))}
+					{SORT_OPTIONS.map((option, idx) => {
+						const active = sortIndex === idx
+						// "Mejor tasa" necesita una moneda: se marca con el icono para
+						// que abrir el picker al tocarlo no salga de la nada
+						const needsCoin = !!option.requiresCoin && !selectedCoin
+						const tint = active ? theme.colors.almostWhite : theme.colors.primaryText
+						return (
+							<Pressable key={option.labelKey} style={[styles.activeBadge, { backgroundColor: active ? theme.colors.primary : theme.colors.surface, borderWidth: 0.5, borderColor: theme.colors.border }]} onPress={() => onSelectSort(idx)}>
+								<Text style={[textStyles.caption, { color: tint, fontSize: theme.typography.fontSize.xs }]}>{t(option.labelKey)}</Text>
+								{needsCoin && <FontAwesome6 name="coins" size={9} color={active ? theme.colors.almostWhite : theme.colors.secondaryText} iconStyle="solid" />}
+							</Pressable>
+						)
+					})}
 				</View>
 			)}
 

--- a/screens/p2p/useP2PFilters.test.js
+++ b/screens/p2p/useP2PFilters.test.js
@@ -24,12 +24,15 @@ const renderFilters = (initialCoin = null) => {
 const set = (f, field, value) => act(() => { f.current.setFilter(field, value) })
 
 describe('initial state', () => {
-	test('defaults: recent sort, page size 30, no filters active', () => {
+	test('defaults: Comprar, recent sort, page size 30, no filters active', () => {
 		const f = renderFilters()
 		expect(f.current.hasActiveFilters).toBeFalsy()
 		expect(f.current.orderBy).toBe('updated_at')
 		expect(f.current.orderType).toBe('desc')
-		expect(f.current.apiFilters).toEqual({ take: 30, order: 'desc', orderBy: 'updated_at', type: null })
+		// El lado del mercado arranca elegido: nunca es null (el switch del
+		// TopBar es un modo, y sin lado la lista mezclaba compras y ventas)
+		expect(f.current.filters.typeFilter).toBe('sell')
+		expect(f.current.apiFilters).toEqual({ take: 30, order: 'desc', orderBy: 'updated_at', type: 'sell' })
 	})
 })
 
@@ -71,7 +74,8 @@ describe('apiFilters', () => {
 
 describe('orden', () => {
 	test('todos los órdenes son de servidor y mantienen la paginación de 30', () => {
-		const f = renderFilters()
+		// Con moneda elegida: `best_rate` la exige y sin ella se degradaría
+		const f = renderFilters({ tick: 'BANK_CUP' })
 		SORT_OPTIONS.forEach((option, index) => {
 			set(f, 'sortIndex', index)
 			expect(f.current.apiFilters).toMatchObject({
@@ -84,9 +88,31 @@ describe('orden', () => {
 
 	test('usa los campos ordenables que el backend acepta', () => {
 		// Lista blanca del servidor: updated_at, created_at, amount, receive,
-		// ratio, rating, trades
-		const valid = ['updated_at', 'created_at', 'amount', 'receive', 'ratio', 'rating', 'trades']
+		// ratio, rating, trades, best_rate
+		const valid = ['updated_at', 'created_at', 'amount', 'receive', 'ratio', 'rating', 'trades', 'best_rate']
 		SORT_OPTIONS.forEach(o => expect(valid).toContain(o.orderBy))
+	})
+
+	test('"mejor tasa" pide best_rate, no ratio (ratio desc devolvía las peores en Comprar)', () => {
+		const bestRate = SORT_OPTIONS.find(o => o.labelKey === 'p2p.filters.sort.bestRate')
+		expect(bestRate).toMatchObject({ orderBy: 'best_rate', orderType: 'desc', requiresCoin: true })
+	})
+
+	test('best_rate sin moneda se degrada al orden por defecto (el backend responde 400)', () => {
+		const f = renderFilters()
+		const index = SORT_OPTIONS.findIndex(o => o.requiresCoin)
+		set(f, 'sortIndex', index)
+		expect(f.current.apiFilters.orderBy).toBe('updated_at')
+		// Y vuelve a aplicarse en cuanto hay moneda
+		set(f, 'selectedCoin', { tick: 'BANK_CUP' })
+		expect(f.current.apiFilters.orderBy).toBe('best_rate')
+	})
+
+	test('best_rate no viaja con "mis ofertas" (mide la conveniencia de quien toma)', () => {
+		const f = renderFilters({ tick: 'BANK_CUP' })
+		set(f, 'sortIndex', SORT_OPTIONS.findIndex(o => o.requiresCoin))
+		set(f, 'showMine', true)
+		expect(f.current.apiFilters.orderBy).toBe('updated_at')
 	})
 })
 

--- a/screens/p2p/useP2PFilters.ts
+++ b/screens/p2p/useP2PFilters.ts
@@ -11,6 +11,8 @@ export type SortOption = {
 	labelKey: string
 	orderBy: string
 	orderType: 'asc' | 'desc'
+	/** El orden solo es aplicable con una moneda elegida (ver `best_rate`). */
+	requiresCoin?: boolean
 }
 
 /** Moneda del picker: el catálogo completo, o el `{ tick, name, logo }` sintético que arma P2P.tsx desde route.params. */
@@ -18,7 +20,13 @@ export type FilterCoin = Pick<Coin, 'tick'> & Partial<Coin>
 
 /** Estado de los filtros del marketplace (los numéricos viven como string: son inputs). */
 export type P2PFiltersState = {
-	typeFilter: 'buy' | 'sell' | null
+	/**
+	 * Lado del mercado. NUNCA es null: el switch del TopBar es un modo, no un
+	 * filtro — sin lado elegido la lista mezclaba compras y ventas mientras la
+	 * píldora del switch se quedaba transparente, y volver a tocar el lado ya
+	 * activo devolvía a ese estado sin nombre.
+	 */
+	typeFilter: 'buy' | 'sell'
 	selectedCoin: FilterCoin | null
 	sortIndex: number
 	showMine: boolean
@@ -41,6 +49,17 @@ export type P2PFilterBadge = { key: string, label: string, onRemove: () => void 
  * Orden de la lista. Todos se resuelven en el servidor: desde 2026-08-16 el
  * backend ordena `ratio` (receive/amount), `rating` y `trades` en SQL con
  * paginación real, así que no queda nada que ordenar en el cliente.
+ *
+ * "Mejor tasa" NO ordena por `ratio`: el ratio es siempre "moneda por USD",
+ * pero su dirección se invierte según el lado del mercado — en una oferta de
+ * venta (pestaña Comprar) el ratio es lo que PAGAS por dólar, así que menos es
+ * mejor; en una de compra es lo que RECIBES, y más es mejor. Pedir `ratio` desc
+ * devolvía por tanto las PEORES ofertas primero en la pestaña Comprar. El
+ * backend expone `best_rate`, que normaliza el signo por tipo para que `desc`
+ * sea siempre "mejor primero" — y exige `type` y `coin` (entre monedas
+ * distintas los ratios no son comparables: 400 CUP/USD vs 1.2 MLC/USD
+ * ordenarían por moneda, no por tasa), de ahí el `requiresCoin`.
+ *
  * El copy no vive aquí: `labelKey` se resuelve con t() en el render (constante
  * de módulo — un literal quedaría congelado en el idioma del arranque).
  */
@@ -48,12 +67,14 @@ export const SORT_OPTIONS: SortOption[] = [
 	{ labelKey: "p2p.filters.sort.recent", orderBy: "updated_at", orderType: "desc" },
 	{ labelKey: "p2p.filters.sort.amountDesc", orderBy: "amount", orderType: "desc" },
 	{ labelKey: "p2p.filters.sort.amountAsc", orderBy: "amount", orderType: "asc" },
-	{ labelKey: "p2p.filters.sort.bestRate", orderBy: "ratio", orderType: "desc" },
+	{ labelKey: "p2p.filters.sort.bestRate", orderBy: "best_rate", orderType: "desc", requiresCoin: true },
 	{ labelKey: "p2p.filters.sort.reputation", orderBy: "rating", orderType: "desc" },
 ]
 
 const initialFilters: P2PFiltersState = {
-	typeFilter: null,
+	// Comprar por defecto (lado izquierdo del switch = ofertas de VENTA ajenas),
+	// como en los P2P de la industria: se entra a comprar
+	typeFilter: "sell",
 	selectedCoin: null,
 	sortIndex: 0,
 	showMine: false,
@@ -116,7 +137,15 @@ export default function useP2PFilters(initialCoin: FilterCoin | null) {
 
 	const { typeFilter, selectedCoin, sortIndex, showMine, opAmount, ratioMin, ratioMax, onlyVip } = filters
 
-	const sortOption = SORT_OPTIONS[sortIndex] || SORT_OPTIONS[0]
+	// Orden efectivo: `best_rate` se degrada al de por defecto cuando no es
+	// aplicable — sin moneda, o en "Mis ofertas" (mide la conveniencia de QUIEN
+	// TOMA la oferta, no la del dueño; el backend responde 400 en ambos casos).
+	// La pantalla pide la moneda ANTES de aplicarlo, así que esto es la red de
+	// seguridad: sin ella saldría una petición que el servidor rechaza y la
+	// lista quedaría vacía.
+	const rawSortOption = SORT_OPTIONS[sortIndex] || SORT_OPTIONS[0]
+	const sortUnavailable = !!rawSortOption.requiresCoin && (!selectedCoin?.tick || showMine)
+	const sortOption = sortUnavailable ? SORT_OPTIONS[0] : rawSortOption
 	const orderBy = sortOption.orderBy
 	const orderType = sortOption.orderType
 
@@ -136,14 +165,12 @@ export default function useP2PFilters(initialCoin: FilterCoin | null) {
 	// alcanzaba a la página cargada, así que una lista podía salir vacía
 	// teniendo resultados en las siguientes
 	const apiFilters = useMemo<P2PIndexFilters>(() => {
-		// `type: null` viaja tal cual (p2pApi.index lo descarta con su guard de
-		// verdad); el cast conserva ese runtime sin ensanchar P2PIndexFilters.
-		const out = {
+		const out: P2PIndexFilters = {
 			take: PAGE_SIZE,
 			order: orderType,
 			orderBy,
 			type: typeFilter,
-		} as P2PIndexFilters
+		}
 		if (showMine) { out.my = true }
 		if (selectedCoin?.tick) { out.coin = selectedCoin.tick }
 		// "Quiero operar $X" → ofertas con al menos ese monto

--- a/ui/P2POfferItem.test.js
+++ b/ui/P2POfferItem.test.js
@@ -197,8 +197,9 @@ describe('counterparty row', () => {
 })
 
 describe('contexto de mercado', () => {
-	// La señal se invierte según el lado: en una oferta de VENTA (yo compro)
-	// una tasa más alta me da más moneda; en una de COMPRA es al revés
+	// La señal se lee desde quien TOMA la oferta: en una de VENTA paga `receive`
+	// por cada QUSD (menos tasa = más barato = a favor); en una de COMPRA lo
+	// recibe (más tasa = a favor). Mismo signo que el orden `best_rate`
 	const withAvg = (offer, avg) => renderItem(offer, { marketAverage: avg })
 	const AVG = { average_buy: 100, average_sell: 100 }
 
@@ -206,17 +207,18 @@ describe('contexto de mercado', () => {
 		expect(plainText(renderItem(makeOffer({ amount: '1', receive: '120' })))).not.toContain('%')
 	})
 
-	test('una oferta de venta con tasa por encima del mercado se marca a favor', () => {
-		expect(plainText(withAvg(makeOffer({ type: 'sell', amount: '1', receive: '110' }), AVG))).toContain('+10.0%')
+	test('una oferta de venta con tasa por debajo del mercado se marca a favor', () => {
+		// Pagas 90 por el QUSD que el mercado cobra a 100
+		expect(plainText(withAvg(makeOffer({ type: 'sell', amount: '1', receive: '90' }), AVG))).toContain('+10.0%')
 	})
 
-	test('una oferta de venta con tasa por debajo se marca en contra', () => {
-		expect(plainText(withAvg(makeOffer({ type: 'sell', amount: '1', receive: '90' }), AVG))).toContain('-10.0%')
+	test('una oferta de venta con tasa por encima se marca en contra', () => {
+		expect(plainText(withAvg(makeOffer({ type: 'sell', amount: '1', receive: '110' }), AVG))).toContain('-10.0%')
 	})
 
 	test('en una oferta de compra el signo se invierte', () => {
-		// receive alto en una oferta de compra = peor para quien la toma
-		expect(plainText(withAvg(makeOffer({ type: 'buy', amount: '1', receive: '110' }), AVG))).toContain('-10.0%')
+		// receive alto en una oferta de compra = recibes más = mejor para quien la toma
+		expect(plainText(withAvg(makeOffer({ type: 'buy', amount: '1', receive: '110' }), AVG))).toContain('+10.0%')
 	})
 
 	test('las diferencias por debajo del 1% no se señalan (ruido)', () => {

--- a/ui/P2POfferItem.tsx
+++ b/ui/P2POfferItem.tsx
@@ -127,15 +127,18 @@ const P2POfferItem = ({ offer, navigation, show_buttons = true, show_user = true
 	const rateValue = amountNum > 0 ? Number(offer.receive) / amountNum : null
 	const rate = rateValue != null ? rateValue.toFixed(2) : '—'
 
-	// Contexto de mercado: cuánto se aleja esta tasa de la media 24h de su
-	// moneda. Para quien COMPRA una oferta de venta, más tasa es mejor; en una
-	// oferta de compra es al revés — de ahí que se compare contra la media del
-	// mismo lado y se invierta el signo según el tipo
+	// Contexto de mercado: cuánto se aleja esta tasa de la media 24h de su misma
+	// moneda y lado. El signo se lee SIEMPRE desde quien TOMA la oferta, que es
+	// quien decide en la lista: en una de venta paga `receive` por cada QUSD
+	// (menos tasa = más barato = mejor), y en una de compra lo recibe (más tasa =
+	// mejor). Estaba al revés, así que una oferta de venta cara se pintaba en
+	// verde — el mismo signo invertido que devolvía las peores primero al ordenar
+	// por tasa (ver `best_rate` en useP2PFilters)
 	const marketAvg = marketAverage
 		? Number(offer.type === 'buy' ? marketAverage.average_buy : marketAverage.average_sell) || null
 		: null
 	const ratePremium = (marketAvg && rateValue) ? ((rateValue - marketAvg) / marketAvg) * 100 : null
-	const rateEdge = ratePremium == null ? null : (offer.type === 'buy' ? -ratePremium : ratePremium)
+	const rateEdge = ratePremium == null ? null : (offer.type === 'buy' ? ratePremium : -ratePremium)
 	// Solo se señala cuando la diferencia es significativa (±1%)
 	const rateBetter = rateEdge != null && rateEdge >= 1
 	const rateWorse = rateEdge != null && rateEdge <= -1


### PR DESCRIPTION
## El problema

Dos síntomas con la misma raíz — el signo del ratio se leía al revés y el lado del mercado se trataba como un filtro opcional.

**1 · El switch Comprar/Vender.** `typeFilter` arrancaba en `null`: la lista traía **todas** las ofertas mientras la píldora del switch se quedaba transparente. Y como `QPSwitch` deselecciona al tocar el lado ya activo (responde `null`), volver a tocar "Comprar" devolvía a ese estado sin nombre — eso es lo que se sentía "pegado".

**2 · "Mejor tasa".** El ratio (`receive/amount`) es siempre "moneda por USD", pero **su dirección se invierte según el lado**:

| Oferta | Quien la toma | El ratio es | Mejor = |
|---|---|---|---|
| `type='sell'` (pestaña **Comprar**) | compra QUSD, envía la moneda | lo que **pagas** por dólar | más **bajo** |
| `type='buy'` (pestaña **Vender**) | vende QUSD, recibe la moneda | lo que **recibes** por dólar | más **alto** |

Pedir `orderBy=ratio` + `desc` devolvía por tanto **las peores ofertas primero en la pestaña Comprar**.

## La solución

### Switch (`P2P.tsx`, `useP2PFilters.ts`)
- `typeFilter` pasa a ser `'buy' | 'sell'`, **nunca null**, y arranca en `'sell'` = pestaña **Comprar** (lado izquierdo), como en los P2P de la industria.
- La pantalla ignora el `null` de `QPSwitch`: tocar el lado activo no lo apaga. El lado del mercado es un modo, no un filtro.

### Orden `best_rate` (`useP2PFilters.ts`, `P2PFilterBar.tsx`)
El backend ya expone `best_rate`, que normaliza el signo por tipo para que `desc` sea siempre "mejor primero" (`scripts/p2p/order.js`, commit `b93cd7ab` de qpweb). La app lo usa ahora en vez de `ratio`.

Como `best_rate` **exige `type` + `coin`** y rechaza `my=true` (400 en cualquiera de los tres casos):
- Elegir "Mejor tasa" sin moneda **abre el picker** y aplica el orden al elegirla; descartar el picker lo cancela.
- Quitar la moneda revierte al orden por defecto (nada de badges que no se aplican).
- `apiFilters` degrada al orden por defecto como red de seguridad, para que **nunca** salga una petición que el servidor va a rechazar.
- La opción lleva un icono de moneda en el menú cuando falta elegirla, para que abrir el picker no salga de la nada.

### Badge ±% de la card (`P2POfferItem.tsx`)
Mismo signo invertido: una oferta de venta **cara** se pintaba en verde con "+10%". Ahora se lee desde quien toma la oferta, igual que `best_rate`.

## ⚠️ Antes de mergear

Requiere **qpweb con `best_rate` desplegado en producción**. Está en `main` (`b93cd7ab`), pero si el deploy no ha subido, el orden devolverá 400 y la app lo mostrará como lista vacía.

## Verificación

- `npm test` — 1761/1761 ✅ (incluye 4 tests nuevos del contrato de `best_rate` y los del badge ±% corregidos)
- `npm run typecheck` ✅
- `npm run i18n:check` ✅ — sin claves nuevas

## Fuera de este PR

Los colores del switch están al revés de la convención de la industria: **Comprar = rojo** (`danger`), **Vender = verde** (`successFill`). No se toca aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3XKePAfSai2AeVuUFi28s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes P2P list queries and sorting semantics; **Mejor tasa** depends on production qpweb exposing `orderBy=best_rate`—otherwise users may see empty lists until the backend is deployed.
> 
> **Overview**
> Bumps the app to **2.4.3** (`app.json`, `package.json`, iOS build numbers) and fixes P2P marketplace behavior around market side and rate ordering.
> 
> The **Comprar/Vender** header switch is now always in a defined mode: `typeFilter` defaults to **Comprar** (`sell` offers) and is never cleared when re-tapping the active side, so the list no longer mixes buy and sell offers with an empty switch state. API requests always include `type`.
> 
> **Mejor tasa** now sorts by backend `best_rate` (not raw `ratio` desc, which ranked worst offers first on Comprar). That sort requires a coin; the UI opens the coin picker when needed, cancels on dismiss, resets sort when the coin is cleared, and `useP2PFilters` degrades invalid `best_rate` requests (no coin or Mis ofertas) so the server is not hit with 400s. The sort menu shows a coin hint on that option.
> 
> **P2POfferItem** market ±% badges use the same taker-centric sign as `best_rate`, so favorable/unfavorable rates are no longer inverted on sell offers. Tests cover the new sort contract and badge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 361ec1957da9f611b5e82ad7c6de118210fda47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->