### PR TITLE
TopBar consistente en los tabs + gate de requisitos del P2P

### DIFF
--- a/api/p2pApi.ts
+++ b/api/p2pApi.ts
@@ -115,7 +115,10 @@ export const p2pApi = {
 				const errorData = error.response.data
 				return {
 					success: false,
-					error: errorData.message || i18n.t('api.p2p.offersLoadFailed'),
+					// El backend manda la razón en `error` (los requisitos de acceso
+					// al P2P entre ellas); `message` es el nombre que usan otros
+					// endpoints — se aceptan los dos antes del genérico
+					error: errorData.error || errorData.message || i18n.t('api.p2p.offersLoadFailed'),
 					details: errorData,
 					status: error.response.status
 				}

--- a/i18n/locales/en/p2p.json
+++ b/i18n/locales/en/p2p.json
@@ -42,6 +42,7 @@
 	"requirements": {
 		"title": "P2P requirements",
 		"subtitle": "Complete the following steps to access the P2P market ({{done}}/3)",
+		"accountBlocked": "If you already completed these steps, your account doesn't have P2P access yet. Contact us from Help and we'll review it.",
 		"kyc": {
 			"label": "Identity verification",
 			"description": "Complete identity verification to trade on P2P"

--- a/i18n/locales/es/p2p.json
+++ b/i18n/locales/es/p2p.json
@@ -42,6 +42,7 @@
 	"requirements": {
 		"title": "Requisitos para P2P",
 		"subtitle": "Completa los siguientes pasos para acceder al mercado P2P ({{done}}/3)",
+		"accountBlocked": "Si ya completaste estos pasos, tu cuenta aún no tiene acceso al P2P. Escríbenos desde Ayuda y lo revisamos.",
 		"kyc": {
 			"label": "Verificación de identidad",
 			"description": "Completa la verificación de identidad para operar en P2P"

--- a/i18n/locales/pt/p2p.json
+++ b/i18n/locales/pt/p2p.json
@@ -42,6 +42,7 @@
 	"requirements": {
 		"title": "Requisitos para P2P",
 		"subtitle": "Complete os passos a seguir para acessar o mercado P2P ({{done}}/3)",
+		"accountBlocked": "Se você já concluiu estas etapas, sua conta ainda não tem acesso ao P2P. Fale conosco pela Ajuda e vamos verificar.",
 		"kyc": {
 			"label": "Verificação de identidade",
 			"description": "Complete a verificação de identidade para negociar no P2P"

--- a/screens/MainStack.tsx
+++ b/screens/MainStack.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Pressable, View, Text, Image, Platform } from 'react-native'
+import { Pressable, View, Text, Platform } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -29,9 +29,6 @@ const Tab = (supportsLiquidGlass
 // Routes
 import { ROUTES } from '../routes'
 
-// Helpers
-import { displayName } from '../helpers/displayName'
-
 // Tab Screens
 import Home from './home/Home'
 import Invest from './invest/Invest'
@@ -50,7 +47,7 @@ import { useAuth } from '../auth/AuthContext'
 import { useSettings } from '../settings/SettingsContext'
 
 // UI Components
-import QPAvatar from '../ui/particles/QPAvatar'
+import HeaderIdentity from '../ui/HeaderIdentity'
 import ErrorBoundary from '../ui/ErrorBoundary'
 import { BottomBarProvider } from '../ui/BottomBarContext'
 import AnimatedTabBar from '../ui/AnimatedTabBar'
@@ -99,7 +96,6 @@ const MainStack = ({ navigation }: MainStackProps) => {
 	const insets = useSafeAreaInsets()
 	const containerStyles = useMemo(() => createContainerStyles(theme), [theme])
 	const textStyles = useMemo(() => createTextStyles(theme), [theme])
-	const qvapayLogo = theme.isDark ? require('../assets/images/ui/qvapay-logo-white.png') : require('../assets/images/ui/logo-qvapay.png')
 
 	// Memoized screen options to prevent liquid glass flash on iOS
 	// TopBar height: 56 + insets.top
@@ -111,9 +107,7 @@ const MainStack = ({ navigation }: MainStackProps) => {
 		headerTintColor: theme.colors.primaryText,
 		// Android fallback
 		headerLeft: () => (
-			<Pressable style={containerStyles.headerLeft} onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)}>
-				<QPAvatar user={user} size={32} />
-			</Pressable>
+			<HeaderIdentity user={user} style={containerStyles.headerLeft} onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)} />
 		),
 		headerRight: () => (
 			<Pressable style={containerStyles.headerRight} onPress={() => navigation.navigate(ROUTES.SCAN_SCREEN)}>
@@ -125,9 +119,7 @@ const MainStack = ({ navigation }: MainStackProps) => {
 			unstable_headerLeftItems: () => [{
 				type: 'custom',
 				element: (
-					<Pressable onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)}>
-						<QPAvatar user={user} size={28} />
-					</Pressable>
+					<HeaderIdentity user={user} native onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)} />
 				),
 				hidesSharedBackground: true,
 			}],
@@ -165,42 +157,6 @@ const MainStack = ({ navigation }: MainStackProps) => {
 	const homeOptions = useMemo(() => ({
 		tabBarLabel: showLabels ? t('navigation.tabs.home') : '',
 		tabBarIcon: getTabIcon(ROUTES.HOME_SCREEN),
-		// Android fallback
-		headerLeft: () => (
-			<Pressable style={containerStyles.headerLeft} onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)}>
-				<QPAvatar user={user} size={36} />
-				<View style={{ marginLeft: 10 }}>
-					<View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-						<Text style={textStyles.h4}>{displayName(user)}</Text>
-						{user!.kyc && (<Image source={require('../assets/images/ui/blue-badge.png')} style={{ width: 16, height: 16 }} />)}
-						{user!.golden_check && (<FontAwesome6 name="crown" size={12} color={theme.colors.gold} iconStyle="solid" />)}
-						{user!.role === 'admin' && (<Image source={qvapayLogo} style={{ width: 16, height: 16 }} />)}
-					</View>
-					<Text style={[textStyles.h6, { color: theme.colors.secondaryText, marginTop: -5 }]}>@{user!.username}</Text>
-				</View>
-			</Pressable>
-		),
-		// iOS 26+ native header items (liquid glass compatible)
-		...(supportsLiquidGlass && {
-			unstable_headerLeftItems: () => [{
-				type: 'custom',
-				element: (
-					<Pressable onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)} style={{ flexDirection: 'row', alignItems: 'center' }}>
-						<QPAvatar user={user} size={36} />
-						<View style={{ marginLeft: 8 }}>
-							<View style={{ flexDirection: 'row', alignItems: 'center', gap: 3 }}>
-								<Text style={textStyles.h4}>{displayName(user)}</Text>
-								{user!.kyc && (<Image source={require('../assets/images/ui/blue-badge.png')} style={{ width: 14, height: 14 }} />)}
-								{user!.golden_check && (<FontAwesome6 name="crown" size={11} color={theme.colors.gold} iconStyle="solid" />)}
-								{user!.role === 'admin' && (<Image source={qvapayLogo} style={{ width: 14, height: 14 }} />)}
-							</View>
-							<Text style={[textStyles.h6, { color: theme.colors.secondaryText, marginTop: -3 }]}>@{user!.username}</Text>
-						</View>
-					</Pressable>
-				),
-				hidesSharedBackground: true,
-			}],
-		}),
 		// Android fallback
 		headerRight: () => (
 			<View style={containerStyles.headerRight}>
@@ -252,7 +208,7 @@ const MainStack = ({ navigation }: MainStackProps) => {
 				},
 			],
 		}),
-	}), [showLabels, showBalance, containerStyles, textStyles, theme, user, navigation, qvapayLogo, t])
+	}), [showLabels, showBalance, containerStyles, textStyles, theme, user, navigation, t])
 
 	const investOptions = useMemo(() => ({
 		tabBarLabel: showLabels ? t('navigation.tabs.invest') : '',
@@ -266,10 +222,31 @@ const MainStack = ({ navigation }: MainStackProps) => {
 		tabBarIcon: getTabIcon(ROUTES.KEYPAD_SCREEN),
 	}), [showLabels, t])
 
+	// El switch Comprar/Vender vive centrado en el header de P2P (P2P.tsx), así
+	// que aquí la identidad se reduce al avatar — mismo tamaño que en el resto
+	// de pestañas para que la barra siga leyéndose igual.
 	const p2pOptions = useMemo(() => ({
 		tabBarLabel: showLabels ? t('navigation.tabs.p2p') : '',
 		tabBarIcon: getTabIcon(ROUTES.P2P_SCREEN),
-	}), [showLabels, t])
+		// P2P.tsx lo repite en su setOptions (junto al switch), pero ahí llega un
+		// frame tarde: sin esto el header entra alineado a la izquierda (default
+		// de Android) y se recoloca al montar la pantalla.
+		headerTitleAlign: 'center' as const,
+		// Android fallback
+		headerLeft: () => (
+			<HeaderIdentity user={user} avatarOnly style={containerStyles.headerLeft} onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)} />
+		),
+		// iOS 26+ native header items (liquid glass compatible)
+		...(supportsLiquidGlass && {
+			unstable_headerLeftItems: () => [{
+				type: 'custom',
+				element: (
+					<HeaderIdentity user={user} avatarOnly native onPress={() => navigation.navigate(ROUTES.SETTINGS_STACK)} />
+				),
+				hidesSharedBackground: true,
+			}],
+		}),
+	}), [showLabels, containerStyles, user, navigation, t])
 
 	const storeOptions = useMemo(() => ({
 		tabBarLabel: showLabels ? t('navigation.tabs.store') : '',

--- a/screens/p2p/P2P.tsx
+++ b/screens/p2p/P2P.tsx
@@ -19,6 +19,7 @@ import P2POffer from "../../ui/P2POfferItem"
 import QPCoinPicker from "../../ui/QPCoinPicker"
 import QPSwitch from "../../ui/particles/QPSwitch"
 import P2PRequirementsGate from "./P2PRequirementsGate"
+import { missingP2PRequirements } from "./p2pRequirements"
 import P2PFilterBar from "./P2PFilterBar"
 import P2PFiltersModal from "./P2PFiltersModal"
 import useP2PFilters, { SORT_OPTIONS } from "./useP2PFilters"
@@ -141,9 +142,13 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 	// Bottom bar (Android scroll-hide)
 	const { bottomBarVisible } = useBottomBar()
 
-	// p2p access gate
+	// p2p access gate: el backend exige los CUATRO requisitos antes de servir
+	// /p2p/index (cuenta habilitada, KYC, teléfono y Telegram). Comprobarlos
+	// aquí evita pedir un listado que va a volver 400 — y el 400 que llegue
+	// igualmente (perfil local desfasado) lo traduce `requirement`.
 	// El `!` es solo de tipos: el tab solo se monta con sesión iniciada
-	const p2pEnabled = user!.p2p_enabled
+	const missingRequirements = useMemo(() => missingP2PRequirements(user!), [user])
+	const p2pEnabled = missingRequirements.length === 0
 
 	// Filters + derived API filters/badges
 	const initialCoin = route?.params?.coin ? { tick: route.params.coin, name: route.params.coinName || route.params.coin, logo: route.params.coin } : null
@@ -153,7 +158,7 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 	// Offers list + pagination + fetch
 	// Todos los filtros son de servidor: cualquiera de ellos debe refetchear
 	const quickKey = JSON.stringify(apiFilters)
-	const { p2pOffers, isLoading, error, refreshing, availableCoins, loadingCoins, marketAverages, onRefresh, handleLoadMore } = useP2POffers({ apiFilters, p2pEnabled, quickKey })
+	const { p2pOffers, isLoading, error, requirement, refreshing, availableCoins, loadingCoins, marketAverages, onRefresh, handleLoadMore } = useP2POffers({ apiFilters, p2pEnabled, quickKey })
 
 	// Modal visibility
 	const [modals, dispatchModals] = useReducer(modalsReducer, { showFiltersModal: false, showCoinPicker: false, showSortMenu: false })
@@ -356,7 +361,9 @@ const P2P = ({ navigation, route }: P2PScreenProps) => {
 		<P2POffer offer={item} navigation={navigation as unknown as RootNav} marketAverage={marketAverages?.[item.coin]} />
 	)
 
-	if (!p2pEnabled) { return <P2PRequirementsGate user={user!} navigation={navigation as unknown as RootNav} theme={theme} textStyles={textStyles} containerStyles={containerStyles} /> }
+	if (!p2pEnabled || requirement) {
+		return <P2PRequirementsGate user={user!} navigation={navigation as unknown as RootNav} theme={theme} textStyles={textStyles} containerStyles={containerStyles} serverMissing={requirement} />
+	}
 
 	return (
 		<View style={containerStyles.subContainer}>

--- a/screens/p2p/P2PCreate.test.js
+++ b/screens/p2p/P2PCreate.test.js
@@ -1,5 +1,5 @@
 /**
- * Behavior tests for the P2P offer creation screen: the p2p_enabled gate, the
+ * Behavior tests for the P2P offer creation screen: the requirements gate, the
  * coin catalog, publish validations (amounts, ratio fields from working_data),
  * the `POST /p2p/create` payload (201 contract) and the saved payment methods
  * picker — node environment with every collaborator mocked (see
@@ -79,7 +79,9 @@ const pressPublish = (tree) => act(async () => { publishButton(tree).props.onPre
 
 beforeEach(() => {
 	jest.clearAllMocks()
-	useAuth.mockReturnValue({ user: { p2p_enabled: true, kyc: 1 } })
+	// Usuario que cumple los CUATRO requisitos del backend: con cualquiera sin
+	// cumplir, la pantalla es la portada de requisitos y no el formulario
+	useAuth.mockReturnValue({ user: { p2p_enabled: true, kyc: 1, phone_verified: 1, telegram_id: '123' } })
 	coinsApi.index.mockResolvedValue({ data: [] })
 	p2pApi.create.mockResolvedValue({ success: true, status: 201, data: { p2p: { uuid: 'offer-1' } } })
 	userApi.getPaymentMethods.mockResolvedValue({ success: true, data: [] })
@@ -88,6 +90,15 @@ beforeEach(() => {
 describe('requirements gate and coin catalog', () => {
 	test('users without p2p_enabled only see the requirements gate', async () => {
 		useAuth.mockReturnValue({ user: { p2p_enabled: false } })
+		const tree = await renderCreate()
+		expect(tree.root.findByType('P2PRequirementsGate')).toBeDefined()
+		expect(tree.root.findAllByType('P2PCreateForm')).toHaveLength(0)
+	})
+
+	// /p2p/create comprueba los mismos cuatro requisitos que el mercado: sin KYC
+	// el formulario solo llevaría a un 400
+	test('sin KYC tampoco se llega al formulario', async () => {
+		useAuth.mockReturnValue({ user: { p2p_enabled: true, kyc: 0, phone_verified: 1, telegram_id: '123' } })
 		const tree = await renderCreate()
 		expect(tree.root.findByType('P2PRequirementsGate')).toBeDefined()
 		expect(tree.root.findAllByType('P2PCreateForm')).toHaveLength(0)

--- a/screens/p2p/P2PCreate.tsx
+++ b/screens/p2p/P2PCreate.tsx
@@ -12,6 +12,7 @@ import QPCoinPicker from "../../ui/QPCoinPicker"
 import P2PCreateForm from "./P2PCreateForm"
 import SavedMethodsModal from "./SavedMethodsModal"
 import P2PRequirementsGate from "./P2PRequirementsGate"
+import { missingP2PRequirements } from "./p2pRequirements"
 
 // Toast
 import { toast } from "sonner-native"
@@ -115,7 +116,9 @@ const P2PCreate = ({ navigation }: NativeStackScreenProps<RootStackParamList, 'P
 	const [isSending, setIsSending] = useState(false)
 	const [workingForm, setWorkingForm] = useState<Record<string, string>>({})
 	// El `!` es solo de tipos: la pantalla vive tras el gate de sesión iniciada
-	const [p2pEnabled] = useState(user!.p2p_enabled)
+	// Los mismos cuatro requisitos que gatean el mercado: /p2p/create los vuelve
+	// a comprobar, así que sin esto el formulario se rellena para nada
+	const [p2pEnabled] = useState(() => missingP2PRequirements(user!).length === 0)
 
 	// Clave de idempotencia del intento: sobrevive a timeouts, 5xx y toques
 	// repetidos — solo rota tras éxito confirmado (evita ofertas dobles y el

--- a/screens/p2p/P2PRequirementsGate.tsx
+++ b/screens/p2p/P2PRequirementsGate.tsx
@@ -5,6 +5,9 @@ import { useTranslation } from 'react-i18next'
 
 import { ROUTES } from '../../routes'
 import QPPressable from '../../ui/particles/QPPressable'
+import { missingP2PRequirements } from './p2pRequirements'
+
+import type { P2PRequirementKey } from './p2pRequirements'
 
 import type { NavigationProp } from '@react-navigation/native'
 import type { Theme } from '../../theme/ThemeContext'
@@ -18,19 +21,32 @@ type P2PRequirementsGateProps = {
 	theme: Theme
 	textStyles: TextStyles
 	containerStyles: ContainerStyles
+	/**
+	 * Requisito que señaló el backend en su 400. Manda sobre el perfil local:
+	 * si el servidor dice que falta el KYC, se pinta pendiente aunque la copia
+	 * cacheada del usuario diga que está hecho.
+	 */
+	serverMissing?: P2PRequirementKey | null
 }
 
 // Shown when the user hasn't met the P2P requirements (KYC + phone + telegram).
 // Shared by the P2P marketplace and the create-offer screens.
-const P2PRequirementsGate = ({ user, navigation, theme, textStyles, containerStyles }: P2PRequirementsGateProps) => {
+const P2PRequirementsGate = ({ user, navigation, theme, textStyles, containerStyles, serverMissing = null }: P2PRequirementsGateProps) => {
 
 	const { t } = useTranslation()
 
+	const isPending = (key: P2PRequirementKey, localPassed: boolean) => !localPassed || serverMissing === key
+
 	const requirements: { key: string, label: string, description: string, icon: string, iconStyle?: 'solid' | 'regular' | 'brand', passed: boolean, route: keyof SettingsStackParamList }[] = [
-		{ key: 'kyc', label: t('p2p.requirements.kyc.label'), description: t('p2p.requirements.kyc.description'), icon: 'shield-halved', passed: !!user.kyc, route: ROUTES.KYC },
-		{ key: 'phone', label: t('p2p.requirements.phone.label'), description: t('p2p.requirements.phone.description'), icon: 'phone', passed: !!user.phone_verified, route: ROUTES.PHONE },
-		{ key: 'telegram', label: t('p2p.requirements.telegram.label'), description: t('p2p.requirements.telegram.description'), icon: 'telegram', iconStyle: 'brand' as const, passed: !!user.telegram_id, route: ROUTES.TELEGRAM },
+		{ key: 'kyc', label: t('p2p.requirements.kyc.label'), description: t('p2p.requirements.kyc.description'), icon: 'shield-halved', passed: !isPending('kyc', !!user.kyc), route: ROUTES.KYC },
+		{ key: 'phone', label: t('p2p.requirements.phone.label'), description: t('p2p.requirements.phone.description'), icon: 'phone', passed: !isPending('phone', !!user.phone_verified), route: ROUTES.PHONE },
+		{ key: 'telegram', label: t('p2p.requirements.telegram.label'), description: t('p2p.requirements.telegram.description'), icon: 'telegram', iconStyle: 'brand' as const, passed: !isPending('telegram', !!user.telegram_id), route: ROUTES.TELEGRAM },
 	]
+
+	// El acceso al P2P también puede estar cerrado por la cuenta (p2p_enabled),
+	// y eso no lo arregla ningún paso de esta lista: se dice explícitamente en
+	// vez de dejar tres checks verdes sin explicación.
+	const accountBlocked = serverMissing === 'p2p_enabled' || missingP2PRequirements(user).includes('p2p_enabled')
 
 	return (
 		<View style={containerStyles.subContainer}>
@@ -38,7 +54,7 @@ const P2PRequirementsGate = ({ user, navigation, theme, textStyles, containerSty
 				<FontAwesome6 name="triangle-exclamation" size={40} color={theme.colors.warning} iconStyle="solid" />
 				<Text style={[textStyles.h2, { color: theme.colors.primaryText, marginTop: 16 }]}>{t('p2p.requirements.title')}</Text>
 				<Text style={[textStyles.body, { color: theme.colors.secondaryText, textAlign: 'center', marginTop: 6, marginBottom: 24 }]}>
-					{t('p2p.requirements.subtitle', { done: [user.kyc, user.phone_verified, user.telegram_id].filter(Boolean).length })}
+					{t('p2p.requirements.subtitle', { done: requirements.filter(req => req.passed).length })}
 				</Text>
 
 				{requirements.map((req) => (
@@ -73,6 +89,12 @@ const P2PRequirementsGate = ({ user, navigation, theme, textStyles, containerSty
 						)}
 					</QPPressable>
 				))}
+
+				{accountBlocked && (
+					<Text style={[textStyles.caption, { color: theme.colors.secondaryText, textAlign: 'center', marginTop: 14 }]}>
+						{t('p2p.requirements.accountBlocked')}
+					</Text>
+				)}
 			</ScrollView>
 		</View>
 	)

--- a/screens/p2p/p2pRequirements.test.js
+++ b/screens/p2p/p2pRequirements.test.js
@@ -1,0 +1,55 @@
+/**
+ * Requisitos de acceso al P2P: qué falta según el perfil local y cómo se
+ * traduce el 400 del backend a un requisito concreto.
+ * @jest-environment node
+ */
+import { missingP2PRequirements, requirementFromApiError } from './p2pRequirements'
+
+const VERIFIED = { p2p_enabled: 1, kyc: 1, phone_verified: 1, telegram_id: '123' }
+
+describe('missingP2PRequirements', () => {
+
+	test('un usuario completo no tiene requisitos pendientes', () => {
+		expect(missingP2PRequirements(VERIFIED)).toEqual([])
+	})
+
+	test('señala el KYC cuando falta', () => {
+		expect(missingP2PRequirements({ ...VERIFIED, kyc: 0 })).toEqual(['kyc'])
+	})
+
+	test('acumula todos los que falten', () => {
+		expect(missingP2PRequirements({ p2p_enabled: 1 })).toEqual(['kyc', 'phone', 'telegram'])
+	})
+
+	test('sin usuario, todo pendiente', () => {
+		expect(missingP2PRequirements(null)).toEqual(['p2p_enabled', 'kyc', 'phone', 'telegram'])
+	})
+})
+
+describe('requirementFromApiError', () => {
+
+	// Las frases exactas de /p2p/index y /p2p/create en qpweb
+	test.each([
+		['Debes completar el KYC para acceder al P2P', 'kyc'],
+		['No tienes KYC para crear una oferta P2P', 'kyc'],
+		['Debes vincular tu cuenta de Telegram para acceder al P2P', 'telegram'],
+		['Debes verificar tu número de teléfono para acceder al P2P', 'phone'],
+		['No tienes habilitado el acceso a P2P', 'p2p_enabled'],
+		['P2P is not enabled for this user', 'p2p_enabled'],
+	])('%s → %s', (message, expected) => {
+		expect(requirementFromApiError(message, 400)).toBe(expected)
+	})
+
+	test('un 400 de validación de filtros NO es un requisito', () => {
+		expect(requirementFromApiError("Parámetro 'page' inválido: debe ser un entero mayor o igual a 1", 400)).toBeNull()
+	})
+
+	test('solo mira los 400 (un 429 o un 500 son fallos de carga)', () => {
+		expect(requirementFromApiError('Debes completar el KYC para acceder al P2P', 429)).toBeNull()
+		expect(requirementFromApiError('Debes completar el KYC para acceder al P2P', undefined)).toBeNull()
+	})
+
+	test('sin mensaje no inventa requisito', () => {
+		expect(requirementFromApiError(null, 400)).toBeNull()
+	})
+})

--- a/screens/p2p/p2pRequirements.ts
+++ b/screens/p2p/p2pRequirements.ts
@@ -1,0 +1,52 @@
+/**
+ * Requisitos de acceso al P2P, en un módulo puro (sin imports de react-native)
+ * para poder testearlo bajo `@jest-environment node`.
+ *
+ * El backend comprueba los mismos cuatro antes de servir `/p2p/index` y
+ * `/p2p/create`, y responde 400 con la razón en prosa — no hay código máquina,
+ * así que el mapeo mensaje → requisito vive aquí.
+ */
+
+import type { User } from '../../types/domain'
+
+/** Los cuatro requisitos que gatean el P2P (el orden es el de la pantalla). */
+export type P2PRequirementKey = 'p2p_enabled' | 'kyc' | 'phone' | 'telegram'
+
+/** Requisitos que el perfil local NO cumple. Vacío = se puede pedir el mercado. */
+export const missingP2PRequirements = (user: User | null | undefined): P2PRequirementKey[] => {
+	const missing: P2PRequirementKey[] = []
+	if (!user?.p2p_enabled) { missing.push('p2p_enabled') }
+	if (!user?.kyc) { missing.push('kyc') }
+	if (!user?.phone_verified) { missing.push('phone') }
+	if (!user?.telegram_id) { missing.push('telegram') }
+	return missing
+}
+
+// Las frases exactas del backend (index + create). Se exige además que el
+// mensaje mencione P2P: los cuatro lo hacen, y así un 400 de validación de
+// filtros (page/orderBy/best_rate) no se confunde con un requisito.
+const ERROR_PATTERNS: [P2PRequirementKey, RegExp][] = [
+	['kyc', /kyc/i],
+	['telegram', /telegram/i],
+	['phone', /tel[ée]fono|phone/i],
+	['p2p_enabled', /habilitado|not enabled/i],
+]
+
+/**
+ * Traduce el 400 del backend al requisito que falta.
+ *
+ * Red de seguridad para el perfil local desfasado (caché vieja, verificación
+ * hecha en otro dispositivo): si el servidor dice que falta el KYC, la pantalla
+ * lo pinta aunque `user.kyc` diga lo contrario.
+ *
+ * @param error - Prosa de error del backend.
+ * @param status - Código HTTP de la respuesta.
+ * @returns El requisito señalado, o null si el 400 es por otra cosa.
+ */
+export const requirementFromApiError = (error?: string | null, status?: number): P2PRequirementKey | null => {
+	if (status !== 400 || !error || !/p2p/i.test(error)) { return null }
+	for (const [key, pattern] of ERROR_PATTERNS) {
+		if (pattern.test(error)) { return key }
+	}
+	return null
+}

--- a/screens/p2p/useP2POffers.test.js
+++ b/screens/p2p/useP2POffers.test.js
@@ -103,6 +103,22 @@ describe('errors', () => {
 		expect(result.current.error).toBe('Error de conexión')
 		expect(toast.error).toHaveBeenCalledWith('Error de conexión')
 	})
+
+	// El 400 por requisitos NO es un fallo de carga: la pantalla cambia a la
+	// portada de requisitos, así que no se pone un toast rojo encima
+	test('un 400 por KYC se expone como requisito y no se toastea', async () => {
+		p2pApi.index.mockResolvedValue({ success: false, status: 400, error: 'Debes completar el KYC para acceder al P2P' })
+		const { result } = await renderOffers()
+		expect(result.current.requirement).toBe('kyc')
+		expect(toast.error).not.toHaveBeenCalled()
+	})
+
+	test('un 400 de validación de filtros sigue siendo un fallo de carga', async () => {
+		p2pApi.index.mockResolvedValue({ success: false, status: 400, error: "Parámetro 'page' inválido" })
+		const { result } = await renderOffers()
+		expect(result.current.requirement).toBeNull()
+		expect(toast.error).toHaveBeenCalledWith("Parámetro 'page' inválido")
+	})
 })
 
 describe('pagination', () => {

--- a/screens/p2p/useP2POffers.ts
+++ b/screens/p2p/useP2POffers.ts
@@ -14,6 +14,9 @@ import { toast } from "sonner-native"
 // al cambiar de idioma
 import i18n from "../../i18n"
 
+import { requirementFromApiError } from "./p2pRequirements"
+
+import type { P2PRequirementKey } from "./p2pRequirements"
 import type { P2PIndexFilters } from "../../api/p2pApi"
 import type { P2POffer } from "../../types/domain"
 
@@ -24,6 +27,8 @@ type ListState = {
 	p2pOffers: P2POffer[]
 	isLoading: boolean
 	error: string | null
+	/** Requisito que el backend exige (400) — la pantalla pinta la portada de requisitos. */
+	requirement: P2PRequirementKey | null
 	refreshing: boolean
 }
 
@@ -36,7 +41,7 @@ type ListAction =
 	| { type: "setOffers", offers: P2POffer[] }
 	| { type: "hydrate", offers: P2POffer[] | null | undefined }
 	| { type: "appendOffers", offers: P2POffer[] }
-	| { type: "error", error: string }
+	| { type: "error", error: string, requirement?: P2PRequirementKey | null }
 	| { type: "finish" }
 
 /** Petición que llegó mientras había otra en vuelo (coalescing). */
@@ -46,13 +51,13 @@ type PendingFetch = { pageNum: number, isRefresh: boolean }
 // una sola petición (el índice permite 10/min por usuario)
 const FILTER_DEBOUNCE_MS = 350
 
-const initialList: ListState = { p2pOffers: [], isLoading: false, error: null, refreshing: false }
+const initialList: ListState = { p2pOffers: [], isLoading: false, error: null, requirement: null, refreshing: false }
 
 function listReducer(state: ListState, action: ListAction): ListState {
 	switch (action.type) {
 		case "start":
 			// kind: 'refresh' | 'more' | 'initial'
-			return { ...state, refreshing: action.kind === "refresh", isLoading: action.kind === "more", error: null }
+			return { ...state, refreshing: action.kind === "refresh", isLoading: action.kind === "more", error: null, requirement: null }
 		case "setOffers":
 			return { ...state, p2pOffers: action.offers }
 		case "hydrate":
@@ -61,7 +66,7 @@ function listReducer(state: ListState, action: ListAction): ListState {
 		case "appendOffers":
 			return { ...state, p2pOffers: [...state.p2pOffers, ...action.offers] }
 		case "error":
-			return { ...state, error: action.error }
+			return { ...state, error: action.error, requirement: action.requirement || null }
 		case "finish":
 			return { ...state, isLoading: false, refreshing: false }
 		default:
@@ -84,11 +89,13 @@ function listReducer(state: ListState, action: ListAction): ListState {
  *
  * @param params.apiFilters - Query params from useP2PFilters; read through a ref, so a changed
  *   object alone does NOT refetch — refreshes are driven by `quickKey` or explicit calls.
- * @param params.p2pEnabled - Gate from user settings; nothing is fetched while false.
+ * @param params.p2pEnabled - Gate de acceso (los cuatro requisitos, ver p2pRequirements);
+ *   nothing is fetched while false.
  * @param params.quickKey - Key derived from the quick filters (type, coin, sort, showMine);
  *   a change auto-refreshes page 1 (skipped on first render — the mount effect covers it).
  * @returns List API:
- *   `p2pOffers`, `isLoading` (initial/load-more), `error`, `refreshing`,
+ *   `p2pOffers`, `isLoading` (initial/load-more), `error`, `requirement` (el 400 del
+ *   backend por KYC/teléfono/Telegram/acceso, ya traducido a clave de requisito), `refreshing`,
  *   `availableCoins` + `loadingCoins` (coin picker),
  *   `fetchP2POffers(pageNum, isRefresh)` (used by the screen to apply modal filters),
  *   `onRefresh` (pull-to-refresh) and `handleLoadMore` (list end reached).
@@ -101,7 +108,7 @@ export default function useP2POffers({ apiFilters, p2pEnabled, quickKey }: {
 }) {
 
 	const [list, dispatchList] = useReducer(listReducer, initialList)
-	const { p2pOffers, isLoading, error, refreshing } = list
+	const { p2pOffers, isLoading, error, requirement, refreshing } = list
 
 	// Pagination cursors — read only inside the fetch/load-more handlers, never rendered
 	const pageRef = useRef(1)
@@ -166,8 +173,13 @@ export default function useP2POffers({ apiFilters, p2pEnabled, quickKey }: {
 				hasMoreRef.current = newData.length >= PAGE_SIZE
 				pageRef.current = pageNum
 			} else {
-				dispatchList({ type: "error", error: response.error || i18n.t('p2p.market.toasts.loadFailed') })
-				toast.error(response.error || i18n.t('p2p.market.toasts.loadFailed'))
+				// Un 400 por requisitos (KYC, teléfono, Telegram, acceso deshabilitado)
+				// no es un fallo de carga: la pantalla cambia a la portada de
+				// requisitos, así que no se grita con un toast rojo encima
+				const requirement = requirementFromApiError(response.error, response.status)
+				const message = response.error || i18n.t('p2p.market.toasts.loadFailed')
+				dispatchList({ type: "error", error: message, requirement })
+				if (!requirement) { toast.error(message) }
 			}
 		} catch (err) {
 			dispatchList({ type: "error", error: i18n.t('p2p.market.toasts.connectionError') })
@@ -234,5 +246,5 @@ export default function useP2POffers({ apiFilters, p2pEnabled, quickKey }: {
 		if (!isLoading && hasMoreRef.current) { fetchP2POffers(pageRef.current + 1) }
 	}, [isLoading, fetchP2POffers])
 
-	return { p2pOffers, isLoading, error, refreshing, availableCoins, loadingCoins, marketAverages, fetchP2POffers, onRefresh, handleLoadMore }
+	return { p2pOffers, isLoading, error, requirement, refreshing, availableCoins, loadingCoins, marketAverages, fetchP2POffers, onRefresh, handleLoadMore }
 }

--- a/ui/HeaderIdentity.test.js
+++ b/ui/HeaderIdentity.test.js
@@ -1,0 +1,59 @@
+/**
+ * Render tests for the tabs' TopBar identity block (avatar + name + badges +
+ * @username), including the avatar-only variant used by P2P — node environment
+ * with theme, icons and QPAvatar mocked (see keypadAmount.test.js for why).
+ * @jest-environment node
+ */
+jest.mock('../theme/ThemeContext', () => {
+	const { createTheme } = jest.requireActual('../theme/ThemeContext')
+	return { useTheme: () => ({ theme: createTheme(true) }) }
+})
+jest.mock('@react-native-vector-icons/fontawesome6', () => 'FontAwesome6')
+jest.mock('./particles/QPAvatar', () => 'QPAvatar')
+
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import { act, create } from 'react-test-renderer'
+import HeaderIdentity from './HeaderIdentity'
+
+const USER = { name: 'Erich', username: 'erich', kyc: 1, golden_check: 0, role: 'user' }
+
+const render = (props = {}) => {
+	let tree
+	act(() => { tree = create(<HeaderIdentity user={USER} onPress={() => { }} {...props} />) })
+	return tree
+}
+
+const avatar = (tree) => tree.root.findByType('QPAvatar')
+const boxHeight = (tree) => StyleSheet.flatten(tree.toJSON().props.style).height
+
+test('shows the name and the @username', () => {
+	const out = JSON.stringify(render().toJSON())
+	expect(out).toContain('Erich')
+	expect(out).toContain('erich')
+})
+
+test('avatarOnly hides the text but keeps the same avatar size', () => {
+	const full = render()
+	const compact = render({ avatarOnly: true })
+	// El nombre viaja también dentro del prop `user` del avatar: se mira el texto pintado
+	expect(compact.root.findAllByType('Text')).toHaveLength(0)
+	expect(avatar(compact).props.size).toBe(avatar(full).props.size)
+})
+
+test('the avatar keeps its size on the native (liquid glass) variant', () => {
+	expect(avatar(render({ native: true })).props.size).toBe(avatar(render()).props.size)
+})
+
+// El texto NO puede mandar en la altura: si la mandara, el avatar saltaría unos
+// píxeles al pasar a P2P (que solo pinta el avatar)
+test('the box height is the same with and without the text', () => {
+	expect(boxHeight(render({ avatarOnly: true }))).toBe(boxHeight(render()))
+	expect(boxHeight(render({ avatarOnly: true, native: true }))).toBe(boxHeight(render({ native: true })))
+})
+
+test('renders the crown only for gold users', () => {
+	const crowns = (tree) => tree.root.findAllByType('FontAwesome6').filter(i => i.props.name === 'crown')
+	expect(crowns(render())).toHaveLength(0)
+	expect(crowns(render({ user: { ...USER, golden_check: 1 } }))).toHaveLength(1)
+})

--- a/ui/HeaderIdentity.tsx
+++ b/ui/HeaderIdentity.tsx
@@ -1,0 +1,98 @@
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native'
+import type { StyleProp, ViewStyle } from 'react-native'
+
+// Icons
+import FontAwesome6 from '@react-native-vector-icons/fontawesome6'
+
+// UI Particles
+import QPAvatar from './particles/QPAvatar'
+
+// Helpers
+import { displayName } from '../helpers/displayName'
+
+// Theme
+import { useTheme } from '../theme/ThemeContext'
+import { useTextStyles } from '../theme/themeUtils'
+
+// Tipos
+import type { User } from '../types/domain'
+
+// El avatar manda: la caja mide siempre lo mismo (36) y el texto se acomoda
+// dentro. Si la altura la fijara el texto (dos líneas de Rubik, y `fontSize`
+// va escalado por el fontScale del sistema), el avatar se movería unos píxeles
+// al saltar a P2P, que solo pinta el avatar.
+const AVATAR_SIZE = 36
+
+// Línea base del TopBar: el header se centra verticalmente, así que este
+// padding sube el contenido 5px. En el header nativo de iOS 26 lo pone el
+// sistema, no nosotros.
+const BASELINE_PADDING = 10
+
+type HeaderIdentityProps = {
+	user: User | null | undefined
+	onPress: () => void
+	/** Solo el avatar (P2P: el switch Comprar/Vender ocupa el centro del header). */
+	avatarOnly?: boolean
+	/** Métricas del header nativo iOS 26 (liquid glass): un pelín más apretadas. */
+	native?: boolean
+	style?: StyleProp<ViewStyle>
+}
+
+/**
+ * Bloque de identidad del TopBar de los tabs: avatar + nombre + verificaciones
+ * (KYC / GOLD / admin) + @username, con el avatar SIEMPRE al mismo tamaño (36)
+ * para que las cinco pestañas se lean como la misma barra.
+ *
+ * @param props
+ * @param props.user - Usuario de sesión.
+ * @param props.onPress - Normalmente navegar a Ajustes.
+ * @param [props.avatarOnly=false] - Oculta el texto (P2P).
+ * @param [props.native=false] - Espaciados del header nativo de iOS 26.
+ * @param [props.style] - Estilo del contenedor (márgenes del header).
+ */
+const HeaderIdentity = ({ user, onPress, avatarOnly = false, native = false, style }: HeaderIdentityProps) => {
+
+	const { theme } = useTheme()
+	const textStyles = useTextStyles(theme)
+	const qvapayLogo = theme.isDark ? require('../assets/images/ui/qvapay-logo-white.png') : require('../assets/images/ui/logo-qvapay.png')
+
+	const badgeSize = native ? 14 : 16
+	const crownSize = native ? 11 : 12
+
+	return (
+		<Pressable
+			style={[
+				styles.container,
+				{ height: AVATAR_SIZE + (native ? 0 : BASELINE_PADDING), paddingBottom: native ? 0 : BASELINE_PADDING },
+				style,
+			]}
+			onPress={onPress}
+		>
+			<QPAvatar user={user} size={AVATAR_SIZE} />
+			{!avatarOnly && (
+				<View style={{ marginLeft: native ? 8 : 10, flexShrink: 1 }}>
+					<View style={[styles.nameRow, { gap: native ? 3 : 4 }]}>
+						<Text style={textStyles.h4} numberOfLines={1}>{displayName(user)}</Text>
+						{!!user?.kyc && (<Image source={require('../assets/images/ui/blue-badge.png')} style={{ width: badgeSize, height: badgeSize }} />)}
+						{!!user?.golden_check && (<FontAwesome6 name="crown" size={crownSize} color={theme.colors.gold} iconStyle="solid" />)}
+						{user?.role === 'admin' && (<Image source={qvapayLogo} style={{ width: badgeSize, height: badgeSize }} />)}
+					</View>
+					<Text style={[textStyles.h6, { color: theme.colors.secondaryText, marginTop: native ? -3 : -5 }]} numberOfLines={1}>@{user?.username}</Text>
+				</View>
+			)}
+		</Pressable>
+	)
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flexDirection: 'row',
+		alignItems: 'center',
+	},
+	nameRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+	},
+})
+
+export default HeaderIdentity


### PR DESCRIPTION
Dos cambios de UI que salieron de la misma sesión.

## 1. Identidad consistente en el TopBar (`feat(ui)`)

El bloque **avatar + nombre + verificaciones + @username** solo existía en Home; Invest, Keypad, P2P y Store heredaban un `headerLeft` con solo el avatar.

- **`ui/HeaderIdentity`**: extrae el bloque (estaba duplicado dentro de `homeOptions`, una copia para Android y otra para el header nativo de iOS 26) y lo comparte desde `screenOptions`. Avatar a **36 en todas las variantes** (antes 32 en el genérico de Android y 28 en iOS).
- **La altura de la caja la fija el avatar, no el texto.** Dos líneas de Rubik con el `fontScale` del sistema medían distinto que el avatar solo, y esa diferencia movía unos píxeles el avatar al cambiar de pestaña.
- **P2P se queda con `avatarOnly`** (el switch Comprar/Vender ocupa el centro del header) y estrena `headerTitleAlign` en sus options estáticas: `P2P.tsx` lo fijaba desde un `useEffect`, así que el header entraba alineado a la izquierda (default de Android) y se recolocaba un frame después.

## 2. Sin KYC se muestran los requisitos, no un error de carga (`fix(p2p)`)

Un usuario sin KYC entraba al P2P y veía *"no se pudieron cargar las ofertas"*. Dos fallos encadenados:

1. **`api/p2pApi.index` leía solo `errorData.message`**, pero el backend manda el motivo en `error` (`"Debes completar el KYC para acceder al P2P"`), así que el 400 se perdía y caía al genérico. El resto del módulo ya aceptaba ambos campos.
2. **La pantalla solo gateaba con `p2p_enabled`**, ignorando los otros tres requisitos que `/p2p/index` exige (KYC, teléfono, Telegram), y pedía un listado condenado al 400.

- **`screens/p2p/p2pRequirements`**: módulo puro con `missingP2PRequirements(user)` y `requirementFromApiError(error, status)`. El backend no manda código máquina, solo prosa, así que el mapeo va por sus frases exactas y exige que mencionen P2P — un 400 de validación de filtros (`page`, `orderBy`, `best_rate`) sigue siendo un fallo de carga.
- **`useP2POffers`** expone `requirement` y calla el toast rojo cuando el 400 es por requisitos (la pantalla entera ya cambia).
- **`P2PRequirementsGate`** acepta `serverMissing`, que **manda sobre el perfil local**: red de seguridad para la caché desfasada (verificación hecha en otro dispositivo). Y dice explícitamente cuándo el bloqueo es de la cuenta (`p2p_enabled`), que antes dejaba tres checks verdes sin explicación ni acción — copy nuevo en es/en/pt.
- **`P2PCreate`** usa el mismo gate: `/p2p/create` comprueba los mismos cuatro requisitos, así que sin KYC se rellenaba el formulario entero para chocar con un 400 al publicar.

## Verificación

- `tsc --noEmit` limpio; `eslint` sin errores.
- `i18n:check` OK (paridad es/en/pt) e `i18n:usage` OK.
- Suite completa **160 suites / 1810 tests en verde**, también en frío tras `--clearCache`.
- Tests nuevos: 13 del módulo de requisitos (incluidas las seis frases literales del backend), 5 de `HeaderIdentity` (uno compara la altura de la caja con y sin texto, para que nadie reintroduzca el shift), 2 en `useP2POffers` y 1 en `P2PCreate`. Actualizado el fixture de `P2PCreate.test.js`, que definía un usuario con `p2p_enabled` y `kyc` pero sin teléfono ni Telegram.

## Nota

El mapeo del 400 depende de la prosa en español del backend. Lo sólido sería añadir un `reason: 'kyc' | 'phone' | …` al 400 en qpweb y leer eso; el módulo está aislado para que ese cambio sea de una línea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3XKePAfSai2AeVuUFi28s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can reach P2P and how API 400s are interpreted; logic is well-tested but requirement detection still depends on backend error prose until a structured reason exists.
> 
> **Overview**
> Unifies the **tab TopBar identity** and fixes **P2P access** so users see requirements instead of a generic load error.
> 
> **TopBar:** New shared `HeaderIdentity` replaces duplicated Home-only header markup and the smaller avatar on other tabs. Avatar stays **36px** with a **fixed container height** so switching to P2P (`avatarOnly`) does not shift the bar. P2P tab options set **`headerTitleAlign: 'center'`** early to avoid a one-frame left-aligned header on Android.
> 
> **P2P gate:** Access now checks all **four** backend requirements (`p2p_enabled`, KYC, phone, Telegram) via `p2pRequirements` before fetching. `p2pApi.index` reads **`error` or `message`** from 400 responses. `useP2POffers` exposes **`requirement`** from parsed 400s and **skips error toasts** when the screen shows `P2PRequirementsGate`; **`serverMissing`** can override stale local profile. Create-offer uses the same gate. New **`accountBlocked`** copy (es/en/pt) when steps are done but P2P is still disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805a426fa3ceb6c045b306ec6b7e4111c00df020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->