### PR TITLE
Widgets de balance: arreglos de fondo y rediseño en tres tamaños

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -230,7 +230,11 @@
               android:resource="@xml/balance_widget_info" />
       </receiver>
 
-      <!-- P2P Offers Widget -->
+      <!-- Widgets de P2P (Ofertas y Tasas) retirados del selector por ahora.
+           El codigo sigue en widget/P2POffersWidget.kt y widget/P2PRatesWidget.kt
+           con sus layouts: para reactivarlos basta con descomentar. -->
+      <!--
+      <!- - P2P Offers Widget - ->
       <receiver
           android:name=".widget.P2POffersWidget"
           android:exported="true">
@@ -242,7 +246,7 @@
               android:resource="@xml/p2p_offers_widget_info" />
       </receiver>
 
-      <!-- P2P Rates Widget -->
+      <!- - P2P Rates Widget - ->
       <receiver
           android:name=".widget.P2PRatesWidget"
           android:exported="true">
@@ -253,5 +257,6 @@
               android:name="android.appwidget.provider"
               android:resource="@xml/p2p_rates_widget_info" />
       </receiver>
+      -->
     </application>
 </manifest>

--- a/android/app/src/main/java/com/qvapay/bridge/SharedStorageModule.kt
+++ b/android/app/src/main/java/com/qvapay/bridge/SharedStorageModule.kt
@@ -25,8 +25,11 @@ class SharedStorageModule(reactContext: ReactApplicationContext) :
             // Trigger widget updates
             val appWidgetManager = AppWidgetManager.getInstance(reactApplicationContext)
 
-            // Update balance widgets
-            if (key == "balance") {
+            // Update balance widgets. `savings` alimenta el bloque de ahorro
+            // del tamano grande: sin escucharla, publicar el resumen no
+            // repintaria nada en Android (reloadWidgets es no-op aqui a
+            // proposito, el refresco lo dispara este modulo).
+            if (key == "balance" || key == "savings") {
                 val balanceComponent = ComponentName(reactApplicationContext, BalanceWidget::class.java)
                 val balanceIds = appWidgetManager.getAppWidgetIds(balanceComponent)
                 if (balanceIds.isNotEmpty()) {

--- a/android/app/src/main/java/com/qvapay/widget/BalanceWidget.kt
+++ b/android/app/src/main/java/com/qvapay/widget/BalanceWidget.kt
@@ -5,13 +5,32 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
 import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.util.SizeF
+import android.util.TypedValue
+import android.view.View
 import android.widget.RemoteViews
 import com.qvapay.R
 import org.json.JSONObject
-import java.text.SimpleDateFormat
-import java.util.*
+import java.text.NumberFormat
+import java.util.Locale
 
+/**
+ * Widget de balance: saldo de la cuenta + accesos directos, en tres tamaños
+ * (2x2, 4x2 y 4x4) y con tema claro/oscuro por `values-night`.
+ *
+ * Los datos los publica `helpers/widgetBridge.ts` en las SharedPreferences
+ * `qvapay_widget_data`: la clave `balance` siempre, y `savings` solo cuando el
+ * Home ha recibido el resumen de ahorro — sin ella el tamaño grande esconde su
+ * bloque en vez de pintar un $0.00 falso.
+ */
 class BalanceWidget : AppWidgetProvider() {
 
     override fun onUpdate(
@@ -22,81 +41,204 @@ class BalanceWidget : AppWidgetProvider() {
         updateAllWidgets(context, appWidgetManager, appWidgetIds)
     }
 
+    /**
+     * Sin esto, en API < 31 redimensionar el widget NO cambia de layout: el
+     * mapa de tamaños de RemoteViews solo existe desde Android 12, así que por
+     * debajo hay que repintar a mano cuando cambian las opciones.
+     */
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle
+    ) {
+        updateWidget(context, appWidgetManager, appWidgetId, readSnapshot(context))
+    }
+
     companion object {
         private const val PREFS_NAME = "qvapay_widget_data"
+
+        /** Umbrales en dp que separan un tamaño del siguiente. */
+        private const val WIDE_DP = 250
+        private const val TALL_DP = 250
+
+        /** Lo que el widget necesita pintar, ya normalizado. */
+        private data class Snapshot(
+            val balance: Double,
+            val savings: Double?,
+            val rate: Double
+        )
 
         fun updateAllWidgets(
             context: Context,
             appWidgetManager: AppWidgetManager,
             appWidgetIds: IntArray
         ) {
-            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            val balanceJson = prefs.getString("balance", null)
-
-            var balance = 0.0
-            var username = ""
-
-            if (balanceJson != null) {
-                try {
-                    val json = JSONObject(balanceJson)
-                    balance = json.optDouble("balance", 0.0)
-                    username = json.optString("username", "")
-                } catch (e: Exception) { /* use defaults */ }
-            }
-
+            val snapshot = readSnapshot(context)
             for (appWidgetId in appWidgetIds) {
-                updateWidget(context, appWidgetManager, appWidgetId, balance, username)
+                updateWidget(context, appWidgetManager, appWidgetId, snapshot)
             }
         }
+
+        private fun readSnapshot(context: Context): Snapshot {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+            val balance = readJson(prefs.getString("balance", null))?.optDouble("balance", 0.0) ?: 0.0
+            val savingsJson = readJson(prefs.getString("savings", null))
+
+            return Snapshot(
+                balance = balance,
+                savings = savingsJson?.optDouble("balance", 0.0),
+                rate = savingsJson?.optDouble("rate", 0.0) ?: 0.0
+            )
+        }
+
+        private fun readJson(raw: String?): JSONObject? {
+            if (raw.isNullOrEmpty()) return null
+            return try { JSONObject(raw) } catch (e: Exception) { null }
+        }
+
+        /** Separador de miles y dos decimales, como `QPBalance` en la app. */
+        private fun money(value: Double): String {
+            val formatter = NumberFormat.getNumberInstance(Locale.getDefault()).apply {
+                minimumFractionDigits = 2
+                maximumFractionDigits = 2
+            }
+            return formatter.format(value)
+        }
+
+        /** La tasa se enseña sin decimales cuando es entera (3.75% pero 4%). */
+        private fun rate(value: Double): String =
+            if (value == Math.floor(value)) String.format(Locale.getDefault(), "%.0f", value)
+            else String.format(Locale.getDefault(), "%.2f", value)
 
         private fun updateWidget(
             context: Context,
             appWidgetManager: AppWidgetManager,
             appWidgetId: Int,
-            balance: Double,
-            username: String
+            snapshot: Snapshot
         ) {
-            val views = RemoteViews(context.packageName, R.layout.widget_balance)
-
-            // Balance text
-            views.setTextViewText(R.id.balance_amount, String.format("$%.2f", balance))
-
-            // Username
-            if (username.isNotEmpty()) {
-                views.setTextViewText(R.id.balance_username, "@$username")
-            }
-
-            // Timestamp
-            val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
-            views.setTextViewText(R.id.balance_timestamp, timeFormat.format(Date()))
-
-            // Deposit button -> deep link
-            val depositIntent = Intent(Intent.ACTION_VIEW, Uri.parse("qvapay://add"))
-            val depositPending = PendingIntent.getActivity(
-                context, 1, depositIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            views.setOnClickPendingIntent(R.id.btn_deposit, depositPending)
-
-            // Withdraw button -> deep link
-            val withdrawIntent = Intent(Intent.ACTION_VIEW, Uri.parse("qvapay://withdraw"))
-            val withdrawPending = PendingIntent.getActivity(
-                context, 2, withdrawIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            views.setOnClickPendingIntent(R.id.btn_withdraw, withdrawPending)
-
-            // Tap on widget body -> open app
-            val openAppIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-            if (openAppIntent != null) {
-                val openPending = PendingIntent.getActivity(
-                    context, 0, openAppIntent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            val views = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                // Android 12+ deja embarcar un layout por tamaño y el launcher
+                // elige sin volver a despertar al proveedor
+                RemoteViews(
+                    mapOf(
+                        SizeF(140f, 140f) to build(context, R.layout.widget_balance_small, snapshot),
+                        SizeF(WIDE_DP.toFloat(), 140f) to build(context, R.layout.widget_balance, snapshot),
+                        SizeF(WIDE_DP.toFloat(), TALL_DP.toFloat()) to build(context, R.layout.widget_balance_large, snapshot)
+                    )
                 )
-                views.setOnClickPendingIntent(R.id.widget_balance_container, openPending)
+            } else {
+                build(context, layoutFor(appWidgetManager, appWidgetId), snapshot)
             }
 
             appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        /** Elección de layout por las dimensiones reportadas (solo API < 31). */
+        private fun layoutFor(appWidgetManager: AppWidgetManager, appWidgetId: Int): Int {
+            val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
+            val minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, WIDE_DP)
+            val minHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 140)
+
+            return when {
+                minWidth >= WIDE_DP && minHeight >= TALL_DP -> R.layout.widget_balance_large
+                minWidth >= WIDE_DP -> R.layout.widget_balance
+                else -> R.layout.widget_balance_small
+            }
+        }
+
+        /** Rubik desde assets/. Cachea: el provider repinta en cada update. */
+        private val typefaces = HashMap<String, Typeface>()
+
+        private fun typeface(context: Context, asset: String): Typeface? =
+            try {
+                typefaces.getOrPut(asset) { Typeface.createFromAsset(context.assets, asset) }
+            } catch (e: Exception) {
+                null // sin la fuente el bitmap sale en la del sistema, no se rompe nada
+            }
+
+        /**
+         * Pinta texto en BLANCO sobre transparente. El color real lo aplica el
+         * `android:tint` del ImageView, que se resuelve al inflar en el launcher
+         * y por tanto sigue a values-night sin que haya que repintar el bitmap.
+         */
+        private fun textBitmap(context: Context, text: String, asset: String, sizeSp: Float): Bitmap {
+            val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                typeface(context, asset)?.let { typeface = it }
+                textSize = TypedValue.applyDimension(
+                    TypedValue.COMPLEX_UNIT_SP, sizeSp, context.resources.displayMetrics
+                )
+                color = Color.WHITE
+            }
+            val metrics = paint.fontMetrics
+            val width = Math.ceil(paint.measureText(text).toDouble()).toInt().coerceAtLeast(1)
+            val height = Math.ceil((metrics.bottom - metrics.top).toDouble()).toInt().coerceAtLeast(1)
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            Canvas(bitmap).drawText(text, 0f, -metrics.top, paint)
+            return bitmap
+        }
+
+        private const val RUBIK_BLACK = "fonts/Rubik-Black.ttf"
+        private const val RUBIK_SEMIBOLD = "fonts/Rubik-SemiBold.ttf"
+
+        /** Cifras por tamano; el simbolo va a la mitad, como en QPBalance. */
+        private fun digitSize(layoutId: Int): Float = when (layoutId) {
+            R.layout.widget_balance_small -> 24f
+            R.layout.widget_balance_large -> 40f
+            else -> 34f
+        }
+
+        private fun build(context: Context, layoutId: Int, snapshot: Snapshot): RemoteViews {
+            val views = RemoteViews(context.packageName, layoutId)
+
+            val digits = digitSize(layoutId)
+            views.setImageViewBitmap(R.id.hero_symbol, textBitmap(context, "$", RUBIK_SEMIBOLD, digits / 2f))
+            views.setImageViewBitmap(R.id.balance_amount, textBitmap(context, money(snapshot.balance), RUBIK_BLACK, digits))
+
+            // Toque en el fondo: el dashboard. Los tiles de abajo lo pisan.
+            views.setOnClickPendingIntent(R.id.widget_balance_container, link(context, "qvapay://home", 0))
+            views.setOnClickPendingIntent(R.id.btn_deposit, link(context, "qvapay://add", 1))
+            views.setOnClickPendingIntent(R.id.btn_send, link(context, "qvapay://send", 3))
+
+            // Extraer y Comerciar solo existen a partir del tamaño mediano
+            if (layoutId != R.layout.widget_balance_small) {
+                views.setOnClickPendingIntent(R.id.btn_withdraw, link(context, "qvapay://withdraw", 2))
+                views.setOnClickPendingIntent(R.id.btn_trade, link(context, "qvapay://p2p", 4))
+            }
+
+            if (layoutId == R.layout.widget_balance_large) {
+                val savings = snapshot.savings
+                if (savings == null) {
+                    views.setViewVisibility(R.id.savings_block, View.GONE)
+                } else {
+                    views.setViewVisibility(R.id.savings_block, View.VISIBLE)
+                    views.setTextViewText(R.id.savings_amount, "$" + money(savings))
+                    views.setTextViewText(
+                        R.id.savings_rate,
+                        context.getString(R.string.widget_rate_suffix, rate(snapshot.rate))
+                    )
+                    val savingsIntent = link(context, "qvapay://savings", 5)
+                    views.setOnClickPendingIntent(R.id.btn_savings_deposit, savingsIntent)
+                    views.setOnClickPendingIntent(R.id.btn_savings_withdraw, savingsIntent)
+                }
+            }
+
+            return views
+        }
+
+        /**
+         * Estas rutas tienen que existir en `linking.ts`; si no, la app abre y
+         * se queda en el Home sin navegar (era el bug de la primera version).
+         */
+        private fun link(context: Context, url: String, requestCode: Int): PendingIntent {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                setPackage(context.packageName)
+            }
+            return PendingIntent.getActivity(
+                context, requestCode, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
         }
     }
 }

--- a/android/app/src/main/res/drawable-v31/widget_container.xml
+++ b/android/app/src/main/res/drawable-v31/widget_container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android 12+ define el radio del contenedor de widget; usarlo evita la doble esquina. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="@android:dimen/system_app_widget_background_radius" />
+    <solid android:color="@color/widget_background" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_widget_deposit.xml
+++ b/android/app/src/main/res/drawable/ic_widget_deposit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/widget_primary_text">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M13.6,3.4h-3.2v7h-7v3.2h7v7h3.2v-7h7v-3.2h-7z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_savings_in.xml
+++ b/android/app/src/main/res/drawable/ic_widget_savings_in.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/widget_success_fill_text">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M12,21.2 4.4,13.6l2.3,-2.3 3.7,3.7V2.8h3.2v12.2l3.7,-3.7 2.3,2.3z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_savings_out.xml
+++ b/android/app/src/main/res/drawable/ic_widget_savings_out.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/widget_success_fill_text">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M12,2.8 19.6,10.4l-2.3,2.3 -3.7,-3.7v12.2h-3.2V9l-3.7,3.7 -2.3,-2.3z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_send.xml
+++ b/android/app/src/main/res/drawable/ic_widget_send.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/widget_primary_text">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M21.8,2.6 2.4,10.4c-0.8,0.3 -0.8,1.4 0,1.7l4.9,1.9L19.6,5.6l-9.4,9.9 8.6,3.4c0.6,0.2 1.3,-0.1 1.4,-0.8l2.6,-14.8c0.1,-0.6 -0.4,-1 -0.9,-0.7z" />
+    <path android:fillColor="#FFFFFFFF" android:pathData="M8.9,16.3v4.4c0,0.8 1,1.1 1.5,0.5l2.2,-2.7z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_trade.xml
+++ b/android/app/src/main/res/drawable/ic_widget_trade.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/widget_primary_text">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M15.6,3 21.4,8l-5.8,5V9.6H7.2V6.4h8.4z" />
+    <path android:fillColor="#FFFFFFFF" android:pathData="M8.4,11 2.6,16l5.8,5v-3.4h8.4v-3.2H8.4z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_withdraw.xml
+++ b/android/app/src/main/res/drawable/ic_widget_withdraw.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/widget_primary_text">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M15.4,2.8 21,10.2h-3.2v7.4h-4.8v-7.4H9.8z" />
+    <path android:fillColor="#FFFFFFFF" android:pathData="M3,21.2v-4.6h10.2v4.6z" />
+</vector>

--- a/android/app/src/main/res/drawable/widget_container.xml
+++ b/android/app/src/main/res/drawable/widget_container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Fondo del widget. En API 31+ el sistema impone su propio radio: ver drawable-v31/. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="@color/widget_background" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_pill.xml
+++ b/android/app/src/main/res/drawable/widget_pill.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Pildora de contexto (QUSD). Redonda a proposito: pildora = estado. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="50dp" />
+    <solid android:color="@color/widget_pill_fill" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_savings_action.xml
+++ b/android/app/src/main/res/drawable/widget_savings_action.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Pill de ahorros: mismo radio que el tile, relleno solido successFill. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="@color/widget_success_fill" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_success_pill.xml
+++ b/android/app/src/main/res/drawable/widget_success_pill.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Pildora de la tasa anual: tinte del verde, no relleno solido. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="50dp" />
+    <solid android:color="@color/widget_success_pill_fill" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_tile.xml
+++ b/android/app/src/main/res/drawable/widget_tile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Tile de accion: squircle 16 como QPPressable/QPButton en la app. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="@color/widget_tile" />
+</shape>

--- a/android/app/src/main/res/layout/widget_balance_large.xml
+++ b/android/app/src/main/res/layout/widget_balance_large.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Widget de balance, tamano 4x2 (el layout por defecto del proveedor). -->
+<!-- Widget de balance, tamano 4x4: cuenta + bloque de ahorro. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_balance_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="14dp"
+    android:padding="16dp"
     android:background="@drawable/widget_container">
 
     <LinearLayout
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/app_name"
-            android:textSize="12sp"
+            android:textSize="13sp"
             android:textColor="@color/widget_secondary_text" />
 
         <TextView
@@ -71,6 +71,15 @@
             android:contentDescription="@string/widget_balance_label" />
     </LinearLayout>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="7dp"
+        android:text="@string/widget_balance_label"
+        android:textSize="12sp"
+        android:textColor="@color/widget_secondary_text" />
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -84,15 +93,15 @@
         <LinearLayout
             android:id="@+id/btn_deposit"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="56dp"
             android:layout_weight="1"
             android:orientation="vertical"
             android:gravity="center"
             android:background="@drawable/widget_tile">
 
             <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
                 android:src="@drawable/ic_widget_deposit"
                 android:contentDescription="@string/widget_action_deposit" />
 
@@ -101,7 +110,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:text="@string/widget_action_deposit"
-                android:textSize="10sp"
+                android:textSize="11sp"
                 android:textColor="@color/widget_primary_text"
                 android:maxLines="1" />
         </LinearLayout>
@@ -109,7 +118,7 @@
         <LinearLayout
             android:id="@+id/btn_withdraw"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="56dp"
             android:layout_weight="1"
             android:layout_marginStart="10dp"
             android:orientation="vertical"
@@ -117,8 +126,8 @@
             android:background="@drawable/widget_tile">
 
             <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
                 android:src="@drawable/ic_widget_withdraw"
                 android:contentDescription="@string/widget_action_withdraw" />
 
@@ -127,7 +136,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:text="@string/widget_action_withdraw"
-                android:textSize="10sp"
+                android:textSize="11sp"
                 android:textColor="@color/widget_primary_text"
                 android:maxLines="1" />
         </LinearLayout>
@@ -135,7 +144,7 @@
         <LinearLayout
             android:id="@+id/btn_send"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="56dp"
             android:layout_weight="1"
             android:layout_marginStart="10dp"
             android:orientation="vertical"
@@ -143,8 +152,8 @@
             android:background="@drawable/widget_tile">
 
             <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
                 android:src="@drawable/ic_widget_send"
                 android:contentDescription="@string/widget_action_send" />
 
@@ -153,7 +162,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:text="@string/widget_action_send"
-                android:textSize="10sp"
+                android:textSize="11sp"
                 android:textColor="@color/widget_primary_text"
                 android:maxLines="1" />
         </LinearLayout>
@@ -161,7 +170,7 @@
         <LinearLayout
             android:id="@+id/btn_trade"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="56dp"
             android:layout_weight="1"
             android:layout_marginStart="10dp"
             android:orientation="vertical"
@@ -169,8 +178,8 @@
             android:background="@drawable/widget_tile">
 
             <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
                 android:src="@drawable/ic_widget_trade"
                 android:contentDescription="@string/widget_action_trade" />
 
@@ -179,9 +188,124 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:text="@string/widget_action_trade"
-                android:textSize="10sp"
+                android:textSize="11sp"
                 android:textColor="@color/widget_primary_text"
                 android:maxLines="1" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/savings_block"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="12dp"
+            android:background="@color/widget_divider" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_savings_title"
+                    android:textSize="11sp"
+                    android:textColor="@color/widget_secondary_text" />
+
+                <TextView
+                    android:id="@+id/savings_amount"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="3dp"
+                    android:text="$0.00"
+                    android:textSize="20sp"
+                    android:textColor="@color/widget_primary_text"
+                    android:maxLines="1" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/savings_rate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="11sp"
+                android:textColor="@color/widget_success_text"
+                android:paddingStart="9dp"
+                android:paddingEnd="9dp"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:background="@drawable/widget_success_pill" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:id="@+id/btn_savings_deposit"
+                android:layout_width="0dp"
+                android:layout_height="44dp"
+                android:layout_weight="1"
+                android:orientation="horizontal"
+                android:gravity="center"
+                android:background="@drawable/widget_savings_action">
+
+                <ImageView
+                    android:layout_width="15dp"
+                    android:layout_height="15dp"
+                    android:src="@drawable/ic_widget_savings_in"
+                    android:contentDescription="@string/widget_savings_deposit" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/widget_savings_deposit"
+                    android:textSize="13sp"
+                    android:textColor="@color/widget_success_fill_text"
+                    android:maxLines="1" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_savings_withdraw"
+                android:layout_width="0dp"
+                android:layout_height="44dp"
+                android:layout_weight="1"
+            android:layout_marginStart="10dp"
+                android:orientation="horizontal"
+                android:gravity="center"
+                android:background="@drawable/widget_savings_action">
+
+                <ImageView
+                    android:layout_width="15dp"
+                    android:layout_height="15dp"
+                    android:src="@drawable/ic_widget_savings_out"
+                    android:contentDescription="@string/widget_savings_withdraw" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/widget_savings_withdraw"
+                    android:textSize="13sp"
+                    android:textColor="@color/widget_success_fill_text"
+                    android:maxLines="1" />
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 

--- a/android/app/src/main/res/layout/widget_balance_small.xml
+++ b/android/app/src/main/res/layout/widget_balance_small.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Widget de balance, tamano 4x2 (el layout por defecto del proveedor). -->
+<!-- Widget de balance, tamano 2x2. Ver widget_balance.xml (4x2) y widget_balance_large.xml (4x4). -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_balance_container"
     android:layout_width="match_parent"
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/app_name"
-            android:textSize="12sp"
+            android:textSize="11sp"
             android:textColor="@color/widget_secondary_text" />
 
         <TextView
@@ -57,7 +57,7 @@
             android:id="@+id/hero_symbol"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="5dp"
+            android:layout_marginEnd="3dp"
             android:adjustViewBounds="true"
             android:tint="@color/widget_secondary_text"
             android:contentDescription="@null" />
@@ -84,15 +84,15 @@
         <LinearLayout
             android:id="@+id/btn_deposit"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="46dp"
             android:layout_weight="1"
             android:orientation="vertical"
             android:gravity="center"
             android:background="@drawable/widget_tile">
 
             <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="14dp"
+                android:layout_height="14dp"
                 android:src="@drawable/ic_widget_deposit"
                 android:contentDescription="@string/widget_action_deposit" />
 
@@ -101,33 +101,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:text="@string/widget_action_deposit"
-                android:textSize="10sp"
-                android:textColor="@color/widget_primary_text"
-                android:maxLines="1" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_withdraw"
-            android:layout_width="0dp"
-            android:layout_height="52dp"
-            android:layout_weight="1"
-            android:layout_marginStart="10dp"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:background="@drawable/widget_tile">
-
-            <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
-                android:src="@drawable/ic_widget_withdraw"
-                android:contentDescription="@string/widget_action_withdraw" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:text="@string/widget_action_withdraw"
-                android:textSize="10sp"
+                android:textSize="9sp"
                 android:textColor="@color/widget_primary_text"
                 android:maxLines="1" />
         </LinearLayout>
@@ -135,16 +109,16 @@
         <LinearLayout
             android:id="@+id/btn_send"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="46dp"
             android:layout_weight="1"
-            android:layout_marginStart="10dp"
+            android:layout_marginStart="8dp"
             android:orientation="vertical"
             android:gravity="center"
             android:background="@drawable/widget_tile">
 
             <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="14dp"
+                android:layout_height="14dp"
                 android:src="@drawable/ic_widget_send"
                 android:contentDescription="@string/widget_action_send" />
 
@@ -153,33 +127,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:text="@string/widget_action_send"
-                android:textSize="10sp"
-                android:textColor="@color/widget_primary_text"
-                android:maxLines="1" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_trade"
-            android:layout_width="0dp"
-            android:layout_height="52dp"
-            android:layout_weight="1"
-            android:layout_marginStart="10dp"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:background="@drawable/widget_tile">
-
-            <ImageView
-                android:layout_width="15dp"
-                android:layout_height="15dp"
-                android:src="@drawable/ic_widget_trade"
-                android:contentDescription="@string/widget_action_trade" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:text="@string/widget_action_trade"
-                android:textSize="10sp"
+                android:textSize="9sp"
                 android:textColor="@color/widget_primary_text"
                 android:maxLines="1" />
         </LinearLayout>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -1,4 +1,16 @@
 <resources>
     <string name="channel_money_in">Money received</string>
     <string name="channel_money_out">Money sent</string>
+    <string name="widget_p2p_rates_description">QvaPay P2P buy and sell rates</string>
+    <string name="widget_balance_description">Your QvaPay balance with quick actions</string>
+    <string name="widget_p2p_offers_description">Your active QvaPay P2P offers</string>
+    <string name="widget_action_deposit">Deposit</string>
+    <string name="widget_action_withdraw">Withdraw</string>
+    <string name="widget_action_send">Send</string>
+    <string name="widget_action_trade">Trade</string>
+    <string name="widget_savings_title">Savings</string>
+    <string name="widget_savings_deposit">Deposit</string>
+    <string name="widget_savings_withdraw">Withdraw</string>
+    <string name="widget_balance_label">Available balance</string>
+    <string name="widget_rate_suffix">%1$s%% a year</string>
 </resources>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Tema OSCURO de los widgets. Ver values/colors.xml para el contrato. -->
+<resources>
+    <color name="widget_background">#FF0E0E1C</color>
+    <color name="widget_tile">#FF1E2039</color>
+    <color name="widget_primary_text">#FFF7F7F7</color>
+    <color name="widget_secondary_text">#FF9DA3B4</color>
+    <color name="widget_pill_fill">#249DA3B4</color>
+    <color name="widget_success_fill">#FF7BFFB1</color>
+    <color name="widget_success_fill_text">#FF0E0E1C</color>
+    <color name="widget_success_text">#FF7BFFB1</color>
+    <color name="widget_success_pill_fill">#247BFFB1</color>
+    <color name="widget_divider">#299DA3B4</color>
+</resources>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,4 +1,16 @@
 <resources>
     <string name="channel_money_in">Dinheiro recebido</string>
     <string name="channel_money_out">Dinheiro enviado</string>
+    <string name="widget_p2p_rates_description">Taxas de compra e venda do P2P da QvaPay</string>
+    <string name="widget_balance_description">Seu saldo da QvaPay com ações rápidas</string>
+    <string name="widget_p2p_offers_description">Suas ofertas ativas no P2P da QvaPay</string>
+    <string name="widget_action_deposit">Depositar</string>
+    <string name="widget_action_withdraw">Sacar</string>
+    <string name="widget_action_send">Enviar</string>
+    <string name="widget_action_trade">Negociar</string>
+    <string name="widget_savings_title">Poupança</string>
+    <string name="widget_savings_deposit">Depositar</string>
+    <string name="widget_savings_withdraw">Resgatar</string>
+    <string name="widget_balance_label">Saldo disponível</string>
+    <string name="widget_rate_suffix">%1$s%% ao ano</string>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Tokens de los widgets de pantalla de inicio, calcados de theme/ThemeContext.tsx.
+  Este fichero es el tema CLARO (configuracion por defecto); values-night/colors.xml
+  trae el oscuro. Los widgets siguen la apariencia del SISTEMA, no el ajuste de
+  tema de la app: ese vive en AsyncStorage, fuera del alcance del launcher.
+-->
+<resources>
+    <color name="widget_background">#FFFFFFFF</color>
+    <color name="widget_tile">#FFE8E9F2</color>
+    <color name="widget_primary_text">#FF1A1A1A</color>
+    <color name="widget_secondary_text">#FF6C757D</color>
+    <color name="widget_pill_fill">#FFE8E9F2</color>
+    <!-- En claro el menta de marca no aguanta sobre blanco: solido oscuro con tinta blanca -->
+    <color name="widget_success_fill">#FF15803D</color>
+    <color name="widget_success_fill_text">#FFFFFFFF</color>
+    <color name="widget_success_text">#FF15803D</color>
+    <color name="widget_success_pill_fill">#1F15803D</color>
+    <color name="widget_divider">#336C757D</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,4 +6,14 @@
     <!-- Nombres de los canales de notificación de dinero (visibles en Ajustes de Android) -->
     <string name="channel_money_in">Dinero recibido</string>
     <string name="channel_money_out">Dinero enviado</string>
+    <!-- Etiquetas de los widgets de balance (las mismas de ui.actionButtons en i18n) -->
+    <string name="widget_action_deposit">Depositar</string>
+    <string name="widget_action_withdraw">Extraer</string>
+    <string name="widget_action_send">Enviar</string>
+    <string name="widget_action_trade">Comerciar</string>
+    <string name="widget_savings_title">Ahorros</string>
+    <string name="widget_savings_deposit">Depositar</string>
+    <string name="widget_savings_withdraw">Retirar</string>
+    <string name="widget_balance_label">Balance disponible</string>
+    <string name="widget_rate_suffix">%1$s%% anual</string>
 </resources>

--- a/android/app/src/main/res/xml/balance_widget_info.xml
+++ b/android/app/src/main/res/xml/balance_widget_info.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Redimensionable de 2x2 a 4x4: el proveedor embarca un layout por tamaño
+  (ver BalanceWidget.kt). targetCell* solo lo lee Android 12+.
+-->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="180dp"
-    android:minHeight="180dp"
-    android:targetCellWidth="2"
-    android:targetCellHeight="3"
-    android:minResizeWidth="110dp"
-    android:minResizeHeight="110dp"
+    android:minWidth="140dp"
+    android:minHeight="140dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:minResizeWidth="140dp"
+    android:minResizeHeight="140dp"
+    android:maxResizeWidth="320dp"
+    android:maxResizeHeight="320dp"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
     android:initialLayout="@layout/widget_balance"

--- a/auth/useAuthState.ts
+++ b/auth/useAuthState.ts
@@ -197,7 +197,10 @@ export default function useAuthState() {
 				setUser(cachedUser)
 				if (cachedUser.uuid) { OneSignal.login(cachedUser.uuid) }
 				if (cachedUser.balance != null && cachedUser.username) {
-					updateWidgetBalance(cachedUser.balance, cachedUser.username)
+					// El await NO es opcional: reloadWidgets dispara
+					// reloadAllTimelines() y en paralelo puede adelantar a la
+					// escritura del App Group, repintando el widget con lo viejo
+					await updateWidgetBalance(cachedUser.balance, cachedUser.username)
 					reloadWidgets()
 				}
 			}
@@ -208,7 +211,7 @@ export default function useAuthState() {
 				if (userData.data.cover && !userData.data.cover_photo_url) { userData.data.cover_photo_url = `https://media.qvapay.com/${userData.data.cover}` }
 				try { await AsyncStorage.setItem(STORAGE_KEYS.USER_DATA, JSON.stringify(userData.data)) } catch (_) { /* cache write failed */ }
 				setUser(userData.data)
-				updateWidgetBalance(userData.data.balance, userData.data.username)
+				await updateWidgetBalance(userData.data.balance, userData.data.username)
 				reloadWidgets()
 				if (userData.data.uuid) { OneSignal.login(userData.data.uuid) }
 			} else if (userData.status === 401 || userData.status === 403) {
@@ -507,7 +510,7 @@ export default function useAuthState() {
 			await AsyncStorage.setItem(STORAGE_KEYS.USER_DATA, JSON.stringify(updatedUser))
 			setUser(updatedUser)
 			// Update home screen widgets with latest balance
-			updateWidgetBalance(updatedUser.balance, updatedUser.username)
+			await updateWidgetBalance(updatedUser.balance, updatedUser.username)
 			reloadWidgets()
 			return { success: true }
 		} catch (e) {

--- a/helpers/widgetBridge.test.js
+++ b/helpers/widgetBridge.test.js
@@ -14,7 +14,7 @@ jest.mock('react-native', () => ({
 }))
 
 import { NativeModules, Platform } from 'react-native'
-import { updateWidgetBalance, updateWidgetP2POffers, reloadWidgets } from './widgetBridge'
+import { updateWidgetBalance, updateWidgetSavings, updateWidgetP2POffers, reloadWidgets } from './widgetBridge'
 
 const { SharedStorage } = NativeModules
 const NOW = new Date('2026-07-07T12:00:00.000Z').getTime()
@@ -36,6 +36,20 @@ describe('updateWidgetBalance', () => {
 		expect(JSON.parse(json)).toEqual({ balance: 123.45, username: 'erich', updatedAt: NOW })
 	})
 
+	// Regresion: el backend manda los decimales como string y el widget de iOS
+	// los lee con `as? Double`, que devuelve nil ante un NSString -> $0.00 fijo
+	test('normalizes a decimal-string balance to a number', async () => {
+		await updateWidgetBalance('1964.45', 'erich')
+		const json = JSON.parse(SharedStorage.setWidgetData.mock.calls[0][1])
+		expect(json.balance).toBe(1964.45)
+	})
+
+	test('falls back to 0 on an unparseable balance', async () => {
+		await updateWidgetBalance('no soy un numero', 'erich')
+		const json = JSON.parse(SharedStorage.setWidgetData.mock.calls[0][1])
+		expect(json.balance).toBe(0)
+	})
+
 	test('defaults nullish balance/username', async () => {
 		await updateWidgetBalance(undefined, undefined)
 		const json = JSON.parse(SharedStorage.setWidgetData.mock.calls[0][1])
@@ -46,6 +60,29 @@ describe('updateWidgetBalance', () => {
 	test('fails silently when the native write throws', async () => {
 		SharedStorage.setWidgetData.mockRejectedValue(new Error('no app group'))
 		await expect(updateWidgetBalance(1, 'x')).resolves.toBeUndefined()
+	})
+})
+
+describe('updateWidgetSavings', () => {
+	// Clave APARTE de `balance`: el widget grande esconde su bloque de ahorro
+	// mientras no exista, en vez de pintar un $0.00 que no es real
+	test('writes the savings snapshot under its own key', async () => {
+		await updateWidgetSavings(842.1, 3.75)
+		const [key, json] = SharedStorage.setWidgetData.mock.calls[0]
+		expect(key).toBe('savings')
+		expect(JSON.parse(json)).toEqual({ balance: 842.1, rate: 3.75, updatedAt: NOW })
+	})
+
+	test('normalizes decimal-strings like the balance path', async () => {
+		await updateWidgetSavings('842.10', '3.75')
+		const json = JSON.parse(SharedStorage.setWidgetData.mock.calls[0][1])
+		expect(json.balance).toBe(842.1)
+		expect(json.rate).toBe(3.75)
+	})
+
+	test('fails silently when the native write throws', async () => {
+		SharedStorage.setWidgetData.mockRejectedValue(new Error('no app group'))
+		await expect(updateWidgetSavings(1, 1)).resolves.toBeUndefined()
 	})
 })
 
@@ -66,8 +103,9 @@ describe('updateWidgetP2POffers', () => {
 		expect(SharedStorage.setWidgetData.mock.calls[0][0]).toBe('p2p_offers')
 		expect(json.count).toBe(7)
 		expect(json.offers).toHaveLength(5)
+		// amount/receive salen del backend como string y se normalizan a number
 		expect(json.offers[0]).toEqual({
-			uuid: 'uuid-1', type: 'buy', coin: 'BANK_MLC', amount: '10.00', receive: '9.50', status: 'open',
+			uuid: 'uuid-1', type: 'buy', coin: 'BANK_MLC', amount: 10, receive: 9.5, status: 'open',
 		})
 	})
 

--- a/helpers/widgetBridge.ts
+++ b/helpers/widgetBridge.ts
@@ -13,6 +13,21 @@ type SharedStorageModule = {
 
 const { SharedStorage } = NativeModules as { SharedStorage?: SharedStorageModule }
 
+/**
+ * Normaliza un decimal del backend a NUMBER. Los importes viajan como string
+ * ("1964.45", ver `Decimal` en types/domain.ts) y el lado nativo de iOS los lee
+ * con `as? Double`, que devuelve nil ante un NSString: sin esta conversion el
+ * widget pintaba $0.00 para siempre (Android se salvaba de casualidad porque
+ * org.json.optDouble si convierte cadenas).
+ *
+ * @param value - Decimal crudo del backend (string, number o nullish).
+ * @returns El numero equivalente, o 0 si no es finito.
+ */
+const toNumber = (value: unknown): number => {
+	const n = Number(value)
+	return Number.isFinite(n) ? n : 0
+}
+
 /** Subset de una oferta P2P que el widget resume (una oferta completa lo cumple). */
 type WidgetP2POffer = {
 	uuid?: string
@@ -26,7 +41,7 @@ type WidgetP2POffer = {
 /**
  * Pushes the latest balance snapshot to the home-screen widgets.
  * Called from AuthContext after each profile fetch. Non-critical: fails silently.
- * @param balance - Current USD balance; admite el decimal-string del backend (defaults to 0).
+ * @param balance - Current USD balance; el decimal-string del backend se normaliza a number (defaults to 0).
  * @param username - Owner's username, shown by the widget.
  */
 export const updateWidgetBalance = async (balance?: number | string | null, username?: string | null): Promise<void> => {
@@ -35,7 +50,7 @@ export const updateWidgetBalance = async (balance?: number | string | null, user
 			await SharedStorage.setWidgetData(
 				'balance',
 				JSON.stringify({
-					balance: balance ?? 0,
+					balance: toNumber(balance),
 					username: username ?? '',
 					updatedAt: Date.now(),
 				})
@@ -47,8 +62,37 @@ export const updateWidgetBalance = async (balance?: number | string | null, user
 }
 
 /**
+ * Pushes the savings summary to the home-screen widgets (the LARGE balance
+ * widget paints a savings block under the account actions).
+ *
+ * Va en una clave APARTE de `balance` a proposito: el resumen de ahorro lo
+ * sirve otra query, llega en otro momento y puede no existir nunca — el widget
+ * oculta el bloque mientras la clave falte, en vez de pintar un $0.00 falso.
+ * Non-critical: fails silently.
+ *
+ * @param balance - Saldo de la cuenta de ahorro (admite el decimal-string del backend).
+ * @param rate - Tasa anual en porcentaje (3.75 = 3.75%).
+ */
+export const updateWidgetSavings = async (balance?: number | string | null, rate?: number | string | null): Promise<void> => {
+	try {
+		if (SharedStorage?.setWidgetData) {
+			await SharedStorage.setWidgetData(
+				'savings',
+				JSON.stringify({
+					balance: toNumber(balance),
+					rate: toNumber(rate),
+					updatedAt: Date.now(),
+				})
+			)
+		}
+	} catch (error) {
+		// Widget update is non-critical, fail silently
+	}
+}
+
+/**
  * Pushes a trimmed summary of the user's P2P offers to the home-screen widgets
- * (first 5 offers, key fields only, plus the total count).
+ * (first 5 offers, key fields only con los importes normalizados a number, plus the total count).
  * Called from the P2P screen after fetching the user's offers. Non-critical: fails silently.
  * @param offers - Full offer objects; reduced to uuid/type/coin/amount/receive/status.
  */
@@ -59,8 +103,8 @@ export const updateWidgetP2POffers = async (offers: WidgetP2POffer[] | null | un
 				uuid: o.uuid,
 				type: o.type,
 				coin: o.coin,
-				amount: o.amount,
-				receive: o.receive,
+				amount: toNumber(o.amount),
+				receive: toNumber(o.receive),
 				status: o.status,
 			}))
 			await SharedStorage.setWidgetData(

--- a/ios/QvaPay.xcodeproj/project.pbxproj
+++ b/ios/QvaPay.xcodeproj/project.pbxproj
@@ -19,18 +19,18 @@
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		80A19C15F0F44B52A1E98F14 /* notification.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 0721CD292AEB4B83975ACAAD /* notification.mp3 */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		A1C4E2F09D6B41F7A8B30C11 /* money_in.caf in Resources */ = {isa = PBXBuildFile; fileRef = A1C4E2F09D6B41F7A8B30C12 /* money_in.caf */; };
+		A1C4E2F09D6B41F7A8B30C21 /* money_out.caf in Resources */ = {isa = PBXBuildFile; fileRef = A1C4E2F09D6B41F7A8B30C22 /* money_out.caf */; };
 		A318F63EDC4646A6BC353698 /* Rubik-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 744F72DE4FF142C5B9489AC9 /* Rubik-MediumItalic.ttf */; };
 		A480A40C4ECB40CDBFF36BD2 /* Rubik-ExtraBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F5CBF97365B148819C5AB0B4 /* Rubik-ExtraBoldItalic.ttf */; };
 		A4C6241C9C09420B9B5C2957 /* Rubik-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E49E54F8521A475FBBDE6436 /* Rubik-Italic.ttf */; };
 		B15C8D6CB1614B5DA682984A /* Rubik-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F830386247324584A758F99F /* Rubik-Regular.ttf */; };
 		BDE8A477E53F40B6930662FD /* money_in.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 03197938F21847F3BA47AD8F /* money_in.mp3 */; };
-		A1C4E2F09D6B41F7A8B30C11 /* money_in.caf in Resources */ = {isa = PBXBuildFile; fileRef = A1C4E2F09D6B41F7A8B30C12 /* money_in.caf */; };
 		CBBEEC46E19B43BCAF779D1F /* Rubik-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8E9D94C077544204A97C61B0 /* Rubik-Black.ttf */; };
 		CF67CAB6313CBE64618CB206 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		D01923873AFB4AF4A0DEC6B9 /* Rubik-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5E8F0AB89ECF41FE9DBC1216 /* Rubik-Medium.ttf */; };
 		D6D1005CBECE4537BF0BA741 /* Rubik-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FF340230807742DD96C8FB8E /* Rubik-ExtraBold.ttf */; };
 		F162D84EB401402DA05A14F7 /* money_out.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 9B210220A594402FA688441D /* money_out.mp3 */; };
-		A1C4E2F09D6B41F7A8B30C21 /* money_out.caf in Resources */ = {isa = PBXBuildFile; fileRef = A1C4E2F09D6B41F7A8B30C22 /* money_out.caf */; };
 		W1000010000000000000000A /* QvaPayWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1000001000000000000000A /* QvaPayWidgetBundle.swift */; };
 		W1000011000000000000000A /* P2PRatesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1000002000000000000000A /* P2PRatesWidget.swift */; };
 		W1000012000000000000000A /* QvaPayAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1000003000000000000000A /* QvaPayAPI.swift */; };
@@ -38,6 +38,10 @@
 		W1000014000000000000000A /* BalanceWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1000007000000000000000A /* BalanceWidget.swift */; };
 		W1000015000000000000000A /* P2POffersWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1000008000000000000000A /* P2POffersWidget.swift */; };
 		W1000071000000000000000A /* QvaPayWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = W1000006000000000000000A /* QvaPayWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		W1000080000000000000000A /* Rubik-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8E9D94C077544204A97C61B0 /* Rubik-Black.ttf */; };
+		W1000081000000000000000A /* Rubik-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5E8F0AB89ECF41FE9DBC1216 /* Rubik-Medium.ttf */; };
+		W1000082000000000000000A /* Rubik-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C02C8B1814194B3F9B8D38C0 /* Rubik-SemiBold.ttf */; };
+		W1000083000000000000000A /* Rubik-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F830386247324584A758F99F /* Rubik-Regular.ttf */; };
 		W2000010000000000000000A /* SharedStorageBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = W2000001000000000000000A /* SharedStorageBridge.swift */; };
 		W2000011000000000000000A /* SharedStorageBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = W2000002000000000000000A /* SharedStorageBridge.m */; };
 		W2000012000000000000000A /* AppIconChanger.swift in Sources */ = {isa = PBXBuildFile; fileRef = W2000003000000000000000A /* AppIconChanger.swift */; };
@@ -70,7 +74,6 @@
 
 /* Begin PBXFileReference section */
 		03197938F21847F3BA47AD8F /* money_in.mp3 */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = money_in.mp3; path = ../assets/sounds/money_in.mp3; sourceTree = "<group>"; };
-		A1C4E2F09D6B41F7A8B30C12 /* money_in.caf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = money_in.caf; path = ../assets/sounds/money_in.caf; sourceTree = "<group>"; };
 		0721CD292AEB4B83975ACAAD /* notification.mp3 */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = notification.mp3; path = ../assets/sounds/notification.mp3; sourceTree = "<group>"; };
 		12ACF633161A4FABBAEE647B /* Rubik-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Rubik-BoldItalic.ttf"; path = "../assets/fonts/Rubik-BoldItalic.ttf"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* QvaPay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QvaPay.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,8 +92,9 @@
 		8E9D94C077544204A97C61B0 /* Rubik-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Rubik-Black.ttf"; path = "../assets/fonts/Rubik-Black.ttf"; sourceTree = "<group>"; };
 		99059718B7394C3883C4903A /* Rubik-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Rubik-Bold.ttf"; path = "../assets/fonts/Rubik-Bold.ttf"; sourceTree = "<group>"; };
 		9B210220A594402FA688441D /* money_out.mp3 */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = money_out.mp3; path = ../assets/sounds/money_out.mp3; sourceTree = "<group>"; };
-		A1C4E2F09D6B41F7A8B30C22 /* money_out.caf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = money_out.caf; path = ../assets/sounds/money_out.caf; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718A1B2C3D4 /* QvaPay.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = QvaPay.entitlements; path = QvaPay/QvaPay.entitlements; sourceTree = "<group>"; };
+		A1C4E2F09D6B41F7A8B30C12 /* money_in.caf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = money_in.caf; path = ../assets/sounds/money_in.caf; sourceTree = "<group>"; };
+		A1C4E2F09D6B41F7A8B30C22 /* money_out.caf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = money_out.caf; path = ../assets/sounds/money_out.caf; sourceTree = "<group>"; };
 		C02C8B1814194B3F9B8D38C0 /* Rubik-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Rubik-SemiBold.ttf"; path = "../assets/fonts/Rubik-SemiBold.ttf"; sourceTree = "<group>"; };
 		DCD46B1CF6A891714EE9EA8F /* Pods-QvaPay.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QvaPay.debug.xcconfig"; path = "Target Support Files/Pods-QvaPay/Pods-QvaPay.debug.xcconfig"; sourceTree = "<group>"; };
 		E49E54F8521A475FBBDE6436 /* Rubik-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Rubik-Italic.ttf"; path = "../assets/fonts/Rubik-Italic.ttf"; sourceTree = "<group>"; };
@@ -352,6 +356,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				W1000080000000000000000A /* Rubik-Black.ttf in Resources */,
+				W1000081000000000000000A /* Rubik-Medium.ttf in Resources */,
+				W1000082000000000000000A /* Rubik-SemiBold.ttf in Resources */,
+				W1000083000000000000000A /* Rubik-Regular.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/QvaPayWidgets/BalanceWidget.swift
+++ b/ios/QvaPayWidgets/BalanceWidget.swift
@@ -7,10 +7,14 @@ struct BalanceEntry: TimelineEntry {
     let date: Date
     let balance: Double
     let username: String
+    /// Saldo de la cuenta de ahorro. `nil` mientras el puente no lo haya
+    /// publicado nunca (instalación nueva o app sin abrir la pantalla de Home).
+    let savings: Double?
+    let savingsRate: Double
     let isPlaceholder: Bool
 
     static var placeholder: BalanceEntry {
-        BalanceEntry(date: Date(), balance: 0.00, username: "usuario", isPlaceholder: true)
+        BalanceEntry(date: Date(), balance: 0.00, username: "usuario", savings: nil, savingsRate: 3.75, isPlaceholder: true)
     }
 }
 
@@ -34,92 +38,413 @@ struct BalanceProvider: TimelineProvider {
         completion(timeline)
     }
 
-    private func readFromStorage() -> BalanceEntry {
-        guard let defaults = UserDefaults(suiteName: BalanceProvider.suiteName),
-              let jsonString = defaults.string(forKey: "balance"),
+    /// Lee un objeto JSON guardado por el puente bajo `key` en el App Group.
+    private func readJSON(_ defaults: UserDefaults, _ key: String) -> [String: Any]? {
+        guard let jsonString = defaults.string(forKey: key),
               let data = jsonString.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+
+    private func readFromStorage() -> BalanceEntry {
+        guard let defaults = UserDefaults(suiteName: BalanceProvider.suiteName),
+              let balanceJSON = readJSON(defaults, "balance") else {
             return .placeholder
         }
 
+        // El ahorro llega por una clave APARTE: lo publica otra query, en otro
+        // momento, y puede no existir todavía (el tamaño large lo oculta).
+        let savingsJSON = readJSON(defaults, "savings")
+
         return BalanceEntry(
             date: Date(),
-            balance: json["balance"] as? Double ?? 0.0,
-            username: json["username"] as? String ?? "",
+            balance: widgetDouble(balanceJSON["balance"]),
+            username: balanceJSON["username"] as? String ?? "",
+            savings: savingsJSON.map { widgetDouble($0["balance"]) },
+            savingsRate: savingsJSON.map { widgetDouble($0["rate"]) } ?? 3.75,
             isPlaceholder: false
         )
+    }
+}
+
+// MARK: - Paleta
+
+/// Los tokens de `theme/ThemeContext.tsx` resueltos por apariencia. El widget
+/// no puede leer el ajuste de tema de la app (vive en AsyncStorage, fuera del
+/// App Group), así que sigue la apariencia del sistema — que es además lo que
+/// esperan iOS y Android de un widget.
+struct QPPalette {
+    let background: Color
+    let tile: Color
+    let primaryText: Color
+    let secondaryText: Color
+    let successFill: Color
+    let successFillText: Color
+    let successText: Color
+    let pillFill: Color
+    let successPillFill: Color
+    let divider: Color
+
+    static func resolve(_ scheme: ColorScheme) -> QPPalette {
+        scheme == .dark ? .dark : .light
+    }
+
+    static let dark = QPPalette(
+        background: Color(hex: "#0E0E1C"),
+        tile: Color(hex: "#1E2039"),
+        primaryText: Color(hex: "#F7F7F7"),
+        secondaryText: Color(hex: "#9DA3B4"),
+        successFill: Color(hex: "#7BFFB1"),
+        successFillText: Color(hex: "#0E0E1C"),
+        successText: Color(hex: "#7BFFB1"),
+        pillFill: Color(hex: "#9DA3B4").opacity(0.14),
+        successPillFill: Color(hex: "#7BFFB1").opacity(0.14),
+        divider: Color(hex: "#9DA3B4").opacity(0.16)
+    )
+
+    static let light = QPPalette(
+        background: Color(hex: "#FFFFFF"),
+        tile: Color(hex: "#E8E9F2"),
+        primaryText: Color(hex: "#1A1A1A"),
+        secondaryText: Color(hex: "#6C757D"),
+        // En claro el menta de marca es ilegible sobre blanco: el sólido va
+        // oscuro con tinta blanca, igual que `successFill` del tema.
+        successFill: Color(hex: "#15803D"),
+        successFillText: Color(hex: "#FFFFFF"),
+        successText: Color(hex: "#15803D"),
+        pillFill: Color(hex: "#E8E9F2"),
+        successPillFill: Color(hex: "#15803D").opacity(0.12),
+        divider: Color(hex: "#6C757D").opacity(0.20)
+    )
+}
+
+// MARK: - Tipografía
+
+/// Rubik, la familia de la app. Los .ttf viajan en el bundle de la extensión
+/// (fase Resources del target + UIAppFonts de su Info.plist); si faltaran,
+/// `Font.custom` cae a la fuente del sistema sin romper nada.
+enum QPFont {
+    static func black(_ size: CGFloat) -> Font { .custom("Rubik-Black", size: size) }
+    static func semiBold(_ size: CGFloat) -> Font { .custom("Rubik-SemiBold", size: size) }
+    static func medium(_ size: CGFloat) -> Font { .custom("Rubik-Medium", size: size) }
+    static func regular(_ size: CGFloat) -> Font { .custom("Rubik-Regular", size: size) }
+}
+
+/// Separador de miles y dos decimales, como `QPBalance` en la app.
+private let moneyFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 2
+    formatter.maximumFractionDigits = 2
+    return formatter
+}()
+
+func formattedMoney(_ value: Double) -> String {
+    moneyFormatter.string(from: NSNumber(value: value)) ?? "0.00"
+}
+
+// MARK: - Destinos
+
+/// Rutas del widget. Todas están declaradas en `linking.ts`; sin esa entrada
+/// el toque abre la app y se queda en el Home.
+enum QPLink {
+    static let home = URL(string: "qvapay://home")
+    static let add = URL(string: "qvapay://add")!
+    static let withdraw = URL(string: "qvapay://withdraw")!
+    static let send = URL(string: "qvapay://send")!
+    static let trade = URL(string: "qvapay://p2p")!
+    static let savings = URL(string: "qvapay://savings")!
+}
+
+// MARK: - Piezas
+
+/// Cabecera: identidad a la izquierda, píldora de contexto a la derecha.
+struct WidgetHeader: View {
+    let palette: QPPalette
+    let title: String
+    let pill: String
+    var pillTint: Color? = nil
+    var pillFill: Color? = nil
+    var titleSize: CGFloat = 12
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(title)
+                .font(QPFont.medium(titleSize))
+                .foregroundColor(palette.secondaryText)
+            Spacer(minLength: 6)
+            Text(pill)
+                .font(QPFont.semiBold(10))
+                .foregroundColor(pillTint ?? palette.secondaryText)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(pillFill ?? palette.pillFill)
+                .clipShape(Capsule())
+        }
+    }
+}
+
+/// Héroe numérico calcado de `QPBalance` (ui/particles/QPBalance.tsx): el
+/// símbolo va en semiBold con la tinta SECUNDARIA y a la mitad del tamaño de
+/// las cifras (30 sobre 60 en la app), centrado en vertical contra ellas — no
+/// por línea base — y la figura entera centrada, como en el BalanceCard.
+struct HeroAmount: View {
+    let amount: Double
+    let digitSize: CGFloat
+    let palette: QPPalette
+
+    /// Proporciones de QPBalance: símbolo a la mitad, separación de 8 sobre 60.
+    private var symbolSize: CGFloat { (digitSize * 0.5).rounded() }
+    private var gap: CGFloat { max(3, (digitSize * 8 / 60).rounded()) }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: gap) {
+            Text("$")
+                .font(QPFont.semiBold(symbolSize))
+                .foregroundColor(palette.secondaryText)
+            Text(formattedMoney(amount))
+                .font(QPFont.black(digitSize))
+                .foregroundColor(palette.primaryText)
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+/// Tile de acción de la cuenta: icono arriba, etiqueta abajo, squircle 16.
+struct ActionTile: View {
+    let symbol: String
+    let label: String
+    let palette: QPPalette
+    var iconSize: CGFloat = 15
+    var labelSize: CGFloat = 10
+    var height: CGFloat = 52
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Image(systemName: symbol)
+                .font(.system(size: iconSize, weight: .semibold))
+                .foregroundColor(palette.primaryText)
+            Text(label)
+                .font(QPFont.medium(labelSize))
+                .foregroundColor(palette.primaryText)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: height)
+        .background(palette.tile)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+/// Pill de ahorros: relleno sólido con su tinta, icono y texto en fila.
+struct SavingsPill: View {
+    let symbol: String
+    let label: String
+    let palette: QPPalette
+    var height: CGFloat = 48
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(palette.successFillText)
+            Text(label)
+                .font(QPFont.semiBold(13))
+                .foregroundColor(palette.successFillText)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: height)
+        .background(palette.successFill)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+// MARK: - Small
+
+/// En `.systemSmall` WidgetKit IGNORA los `Link`: todo el widget es un único
+/// destino. Los tiles se dibujan como indicadores y el toque abre el dashboard.
+struct BalanceSmallView: View {
+    let entry: BalanceEntry
+    let palette: QPPalette
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            WidgetHeader(palette: palette, title: "QvaPay", pill: "QUSD", titleSize: 11)
+
+            Spacer(minLength: 8)
+
+            HeroAmount(amount: entry.balance, digitSize: 24, palette: palette)
+
+            Spacer(minLength: 8)
+
+            HStack(spacing: 8) {
+                ActionTile(symbol: "plus", label: "Depositar", palette: palette, iconSize: 14, labelSize: 9, height: 46)
+                ActionTile(symbol: "paperplane.fill", label: "Enviar", palette: palette, iconSize: 14, labelSize: 9, height: 46)
+            }
+        }
+    }
+}
+
+// MARK: - Medium
+
+struct BalanceMediumView: View {
+    let entry: BalanceEntry
+    let palette: QPPalette
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            WidgetHeader(palette: palette, title: "QvaPay", pill: "QUSD")
+
+            Spacer(minLength: 10)
+
+            HeroAmount(amount: entry.balance, digitSize: 34, palette: palette)
+
+            Spacer(minLength: 10)
+
+            HStack(spacing: 10) {
+                Link(destination: QPLink.add) {
+                    ActionTile(symbol: "plus", label: "Depositar", palette: palette)
+                }
+                Link(destination: QPLink.withdraw) {
+                    ActionTile(symbol: "arrow.turn.up.right", label: "Extraer", palette: palette)
+                }
+                Link(destination: QPLink.send) {
+                    ActionTile(symbol: "paperplane.fill", label: "Enviar", palette: palette)
+                }
+                Link(destination: QPLink.trade) {
+                    ActionTile(symbol: "arrow.left.arrow.right", label: "Comerciar", palette: palette)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Large
+
+struct BalanceLargeView: View {
+    let entry: BalanceEntry
+    let palette: QPPalette
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            WidgetHeader(palette: palette, title: "QvaPay", pill: "QUSD", titleSize: 13)
+
+            Spacer(minLength: 12)
+
+            VStack(spacing: 7) {
+                HeroAmount(amount: entry.balance, digitSize: 44, palette: palette)
+                Text("Balance disponible")
+                    .font(QPFont.regular(12))
+                    .foregroundColor(palette.secondaryText)
+            }
+            .frame(maxWidth: .infinity)
+
+            Spacer(minLength: 14)
+
+            HStack(spacing: 10) {
+                Link(destination: QPLink.add) {
+                    ActionTile(symbol: "plus", label: "Depositar", palette: palette, iconSize: 16, labelSize: 11, height: 56)
+                }
+                Link(destination: QPLink.withdraw) {
+                    ActionTile(symbol: "arrow.turn.up.right", label: "Extraer", palette: palette, iconSize: 16, labelSize: 11, height: 56)
+                }
+                Link(destination: QPLink.send) {
+                    ActionTile(symbol: "paperplane.fill", label: "Enviar", palette: palette, iconSize: 16, labelSize: 11, height: 56)
+                }
+                Link(destination: QPLink.trade) {
+                    ActionTile(symbol: "arrow.left.arrow.right", label: "Comerciar", palette: palette, iconSize: 16, labelSize: 11, height: 56)
+                }
+            }
+
+            // El bloque de ahorro solo aparece cuando el puente lo ha publicado:
+            // dibujar $0.00 cuando en realidad no hay dato sería mentir.
+            if let savings = entry.savings {
+                Spacer(minLength: 16)
+
+                Rectangle()
+                    .fill(palette.divider)
+                    .frame(height: 1)
+
+                Spacer(minLength: 16)
+
+                HStack(alignment: .center) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Ahorros")
+                            .font(QPFont.regular(11))
+                            .foregroundColor(palette.secondaryText)
+                        Text("$\(formattedMoney(savings))")
+                            .font(QPFont.semiBold(20))
+                            .foregroundColor(palette.primaryText)
+                            .minimumScaleFactor(0.6)
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 8)
+                    Text("\(formattedRate(entry.savingsRate))% anual")
+                        .font(QPFont.semiBold(11))
+                        .foregroundColor(palette.successText)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 4)
+                        .background(palette.successPillFill)
+                        .clipShape(Capsule())
+                }
+
+                Spacer(minLength: 10)
+
+                HStack(spacing: 10) {
+                    Link(destination: QPLink.savings) {
+                        SavingsPill(symbol: "arrow.down", label: "Depositar", palette: palette)
+                    }
+                    Link(destination: QPLink.savings) {
+                        SavingsPill(symbol: "arrow.up", label: "Retirar", palette: palette)
+                    }
+                }
+            } else {
+                Spacer()
+            }
+        }
+    }
+
+    /// La tasa se enseña sin decimales cuando es entera (3.75% pero 4%).
+    private func formattedRate(_ rate: Double) -> String {
+        rate == rate.rounded() ? String(format: "%.0f", rate) : String(format: "%.2f", rate)
     }
 }
 
 // MARK: - Widget View
 
 struct BalanceWidgetView: View {
+    @Environment(\.widgetFamily) private var family
+    @Environment(\.colorScheme) private var colorScheme
     let entry: BalanceEntry
 
+    private var palette: QPPalette { QPPalette.resolve(colorScheme) }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header: QvaPay label + QUSD pill
-            HStack {
-                Text("QvaPay")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.white)
-                Spacer()
-                Text("QUSD")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundColor(.white.opacity(0.7))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.white.opacity(0.15))
-                    .cornerRadius(10)
+        content
+            .padding(family == .systemLarge ? 16 : 14)
+            // Destino de reserva: en small es el ÚNICO (los Link no cuentan);
+            // en medium y large cubre el fondo entre tiles.
+            .widgetURL(QPLink.home)
+            .containerBackground(for: .widget) {
+                palette.background
             }
+    }
 
-            Spacer()
-
-            // Balance
-            Text(String(format: "$%.2f", entry.balance))
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundColor(.white)
-                .minimumScaleFactor(0.6)
-                .lineLimit(1)
-
-            // Label
-            Text("Balance actual")
-                .font(.system(size: 11))
-                .foregroundColor(Color.white.opacity(0.45))
-                .padding(.top, 2)
-
-            Spacer()
-
-            // Action buttons: circular + and -
-            HStack(spacing: 12) {
-                Link(destination: URL(string: "qvapay://add")!) {
-                    Circle()
-                        .fill(Color(hex: "#7BFFB1").opacity(0.25))
-                        .frame(width: 36, height: 36)
-                        .overlay(
-                            Image(systemName: "plus")
-                                .font(.system(size: 15, weight: .bold))
-                                .foregroundColor(Color(hex: "#7BFFB1"))
-                        )
-                }
-
-                Link(destination: URL(string: "qvapay://withdraw")!) {
-                    Circle()
-                        .fill(Color(hex: "#DB253E").opacity(0.25))
-                        .frame(width: 36, height: 36)
-                        .overlay(
-                            Image(systemName: "minus")
-                                .font(.system(size: 15, weight: .bold))
-                                .foregroundColor(Color(hex: "#DB253E"))
-                        )
-                }
-
-                Spacer()
-            }
-        }
-        .padding(14)
-        .containerBackground(for: .widget) {
-            Color(hex: "#0E0E1C")
+    @ViewBuilder
+    private var content: some View {
+        switch family {
+        case .systemLarge:
+            BalanceLargeView(entry: entry, palette: palette)
+        case .systemMedium:
+            BalanceMediumView(entry: entry, palette: palette)
+        default:
+            BalanceSmallView(entry: entry, palette: palette)
         }
     }
 }
@@ -135,16 +460,19 @@ struct BalanceWidget: Widget {
         }
         .configurationDisplayName("Balance")
         .description("Tu balance de QvaPay con acciones rápidas")
-        .supportedFamilies([.systemSmall])
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
 
 // MARK: - Preview
 
 #if DEBUG
-#Preview("Balance", as: .systemSmall) {
-    BalanceWidget()
-} timeline: {
-    BalanceEntry(date: Date(), balance: 1964.45, username: "erich", isPlaceholder: false)
-}
+private let previewEntry = BalanceEntry(
+    date: Date(), balance: 1964.45, username: "erich",
+    savings: 842.10, savingsRate: 3.75, isPlaceholder: false
+)
+
+#Preview("Balance small", as: .systemSmall) { BalanceWidget() } timeline: { previewEntry }
+#Preview("Balance medium", as: .systemMedium) { BalanceWidget() } timeline: { previewEntry }
+#Preview("Balance large", as: .systemLarge) { BalanceWidget() } timeline: { previewEntry }
 #endif

--- a/ios/QvaPayWidgets/Info.plist
+++ b/ios/QvaPayWidgets/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Rubik-Black.ttf</string>
+		<string>Rubik-Medium.ttf</string>
+		<string>Rubik-SemiBold.ttf</string>
+		<string>Rubik-Regular.ttf</string>
+	</array>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/QvaPayWidgets/Models.swift
+++ b/ios/QvaPayWidgets/Models.swift
@@ -68,3 +68,17 @@ struct CoinPair: Identifiable {
         }
     }
 }
+
+// MARK: - Decimales del backend
+
+/// Los importes de QvaPay viajan como string ("1964.45") o como número según
+/// el endpoint. `as? Double` devuelve nil ante un NSString, así que leerlos
+/// directamente pintaba 0 en todos los widgets. Acepta ambas formas.
+///
+/// - Parameter value: Valor crudo salido de `JSONSerialization`.
+/// - Returns: El Double equivalente, o 0 si no se puede interpretar.
+func widgetDouble(_ value: Any?) -> Double {
+    if let number = value as? NSNumber { return number.doubleValue }
+    if let string = value as? String { return Double(string) ?? 0 }
+    return 0
+}

--- a/ios/QvaPayWidgets/P2POffersWidget.swift
+++ b/ios/QvaPayWidgets/P2POffersWidget.swift
@@ -59,8 +59,8 @@ struct P2POffersProvider: TimelineProvider {
                 uuid: item["uuid"] as? String ?? "",
                 type: item["type"] as? String ?? "",
                 coin: item["coin"] as? String ?? "",
-                amount: item["amount"] as? Double ?? 0,
-                receive: item["receive"] as? Double ?? 0,
+                amount: widgetDouble(item["amount"]),
+                receive: widgetDouble(item["receive"]),
                 status: item["status"] as? String ?? ""
             )
         }

--- a/ios/QvaPayWidgets/QvaPayWidgetBundle.swift
+++ b/ios/QvaPayWidgets/QvaPayWidgetBundle.swift
@@ -4,8 +4,11 @@ import SwiftUI
 @main
 struct QvaPayWidgetBundle: WidgetBundle {
     var body: some Widget {
-        P2PRatesWidget()
         BalanceWidget()
-        P2POffersWidget()
+        // Widgets de P2P (Tasas y Ofertas) retirados del selector por ahora.
+        // El codigo sigue en P2PRatesWidget.swift y P2POffersWidget.swift:
+        // para reactivarlos basta con descomentar estas dos lineas.
+        // P2PRatesWidget()
+        // P2POffersWidget()
     }
 }

--- a/linking.ts
+++ b/linking.ts
@@ -12,6 +12,7 @@ import type { RootStackParamList } from './types/navigation'
  *   /store/:slug   → MarketStore (marketplace storefront)
  *   /store/:slug/:uuid → MarketProduct (public product sheet)
  *   /home, /p2p    → tabs inside MainStack
+ *   /add, /withdraw, /send, /savings → accesos directos de los widgets
  *
  * Links that arrive while unauthenticated are NOT resolved here — App.tsx's
  * `pendingDeepLinkRef` stashes the URL (see hooks/useAppNavigation) and
@@ -28,6 +29,13 @@ const linking: LinkingOptions<RootStackParamList> = {
 			[ROUTES.P2P_OFFER_SCREEN]: 'p2p/:p2p_uuid',
 			[ROUTES.PAY_SCREEN]: 'pay/:uuid',
 			[ROUTES.TOPUP_SCREEN]: 'topup',
+			// Accesos directos de los widgets de pantalla de inicio: los botones
+			// mandan qvapay://add|withdraw|send|savings y sin estas entradas la app
+			// abria en el Home sin navegar a ningun sitio
+			[ROUTES.ADD]: 'add',
+			[ROUTES.WITHDRAW]: 'withdraw',
+			[ROUTES.SEND]: 'send',
+			[ROUTES.SAVINGS_SCREEN]: 'savings',
 			// El patrón de producto (2 segmentos) va antes que el de tienda (1)
 			[ROUTES.MARKET_PRODUCT]: 'store/:slug/:uuid',
 			[ROUTES.MARKET_STORE]: 'store/:slug',

--- a/routes.test.js
+++ b/routes.test.js
@@ -54,6 +54,13 @@ describe('linking config', () => {
 		expect(linking.config.screens[ROUTES.PAY_SCREEN]).toBe('pay/:uuid')
 	})
 
+	test('maps the home-screen widget shortcuts', () => {
+		expect(linking.config.screens[ROUTES.ADD]).toBe('add')
+		expect(linking.config.screens[ROUTES.WITHDRAW]).toBe('withdraw')
+		expect(linking.config.screens[ROUTES.SEND]).toBe('send')
+		expect(linking.config.screens[ROUTES.SAVINGS_SCREEN]).toBe('savings')
+	})
+
 	test('maps home and p2p tabs inside MainStack', () => {
 		const main = linking.config.screens[ROUTES.MAIN_STACK]
 		expect(main.screens[ROUTES.HOME_SCREEN]).toBe('home')

--- a/ui/BalanceCard.tsx
+++ b/ui/BalanceCard.tsx
@@ -20,6 +20,9 @@ import { useSettings } from '../settings/SettingsContext'
 // Resumen de ahorros (React Query, query compartida con el dashboard de Invest)
 import { useSavingsSummaryQuery } from '../hooks/useSavingsSummaryQuery'
 
+// Espejo del resumen hacia los widgets de pantalla de inicio
+import { updateWidgetSavings, reloadWidgets } from '../helpers/widgetBridge'
+
 // Particles
 import QPBalance from './particles/QPBalance'
 import QPFitText from './particles/QPFitText'
@@ -76,6 +79,19 @@ const BalanceCard = ({ balance, navigation, refreshing = false, pageProgress }: 
 		balance: summary.data ? (summary.data.balance ?? 0) : null,
 		rate: summary.data?.rate ?? DEFAULT_RATE,
 	}
+
+	// El widget grande pinta un bloque de ahorro, y su dato NO viaja con el
+	// perfil (updateWidgetBalance): se publica aqui, que es la superficie que el
+	// widget replica y esta montada siempre que hay sesion. El await antes de
+	// recargar evita que reloadAllTimelines() adelante a la escritura.
+	useEffect(() => {
+		if (savings.balance == null) return
+		const publish = async () => {
+			await updateWidgetSavings(savings.balance, savings.rate)
+			reloadWidgets()
+		}
+		publish()
+	}, [savings.balance, savings.rate])
 
 	// Load balance visibility setting on component mount
 	useEffect(() => {


### PR DESCRIPTION
Los widgets de pantalla de inicio no funcionaban. Este PR arregla la causa y aprovecha para llevarlos al diseño del `BalanceCard` del Home, en tres tamaños y con tema claro/oscuro en iOS y Android.

## Por qué no funcionaban

| | |
|---|---|
| **Saldo en $0.00** | Los decimales del backend viajan como string (`"1964.45"`). Swift los leía con `as? Double`, que devuelve `nil` ante un `NSString`. Android se salvaba de casualidad porque `org.json.optDouble` sí convierte cadenas. Mismo defecto en `amount`/`receive` del widget de ofertas. |
| **Botones que no navegaban** | Mandaban `qvapay://add\|withdraw`, rutas que `linking.ts` no resolvía: la app abría y se quedaba en el Home. |
| **Carrera al recargar** | `updateWidgetBalance` y `reloadWidgets` iban en paralelo sin `await`, así que `reloadAllTimelines()` podía adelantar a la escritura del App Group. |
| **"Couldn't add widget" en Android** | `<View>` no se puede inflar en un widget: el filtro de RemoteViews exige `@RemoteView` y `android.view.View` no la lleva. Ya venía en el layout original. |

El test del puente solo cubría un balance numérico, por eso el primero sobrevivió tanto tiempo. Ahora cubre el caso string.

## Rediseño

Tres tamaños (small, medium, large) en claro y oscuro. Héroe calcado de `QPBalance`: cifras en Rubik Black, símbolo en semiBold a la mitad del tamaño y con la tinta secundaria, centrado. Tiles squircle de 16 como `ActionButtons`. El tamaño grande añade un bloque de ahorro, que **solo aparece cuando el Home ha publicado el resumen** en vez de pintar un `$0.00` falso.

## Dos limitaciones de plataforma que condicionan el resultado

- **WidgetKit ignora los `Link` en `.systemSmall`**: el widget pequeño es un único destino. Los dos botones que había allí eran decorativos; ahora todo el widget abre el dashboard vía `.widgetURL`.
- **`android:fontFamily` se ignora al inflar RemoteViews**: el launcher no resuelve recursos de fuente, así que Rubik no llegaba nunca aunque el recurso estuviera en el APK. El héroe se pinta a bitmap con `Typeface.createFromAsset`, en blanco sobre transparente, y el color lo pone `android:tint` para que claro/oscuro siga a `values-night` sin repintar. Las etiquetas se quedan en la fuente del sistema **a propósito**: en bitmap dejarían de escalar con el ajuste de accesibilidad, a cambio de una diferencia inapreciable a 10sp. `res/font/` se elimina por inútil (**−816 KB de APK**).

## Fuera del selector

Los widgets de Ofertas P2P y Tasas P2P quedan comentados en el manifest y en `QvaPayWidgetBundle.swift`. El código sigue intacto: descomentar dos líneas y vuelven.

## Verificación

- `:app:compileDebugKotlin` y `:app:installDebug` correctos; widget probado en un Galaxy real (One UI), confirmado por captura
- Target `QvaPayWidgetsExtension` compilando contra `iphoneos`, con los cuatro Rubik dentro del `.appex`
- Workspace completo de iOS: `** BUILD SUCCEEDED **`
- `tsc --noEmit` limpio, ESLint sin errores nuevos, **1828 tests en 161 suites**

## Pendiente de probar

Los tamaños 2x2 y 4x4 en Android sobre distintos launchers: la altura de celda varía y los dp del grande están ajustados a ojo.

> [!NOTE]
> La rama traía ya dos commits previos (`1cbaf5f`, `72995ce`) que no son de este trabajo y entran en el diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Toca deep linking, sesión/auth (await en arranque) y widgets nativos en ambas plataformas; el impacto en UX es alto pero acotado a pantalla de inicio y rutas nuevas explícitas.
> 
> **Overview**
> **Arregla los widgets de balance que mostraban $0.00, botones muertos y datos desactualizados**, y los rediseña alineados con el `BalanceCard` del Home en **tres tamaños** (small / medium / large) con tema claro/oscuro según el sistema en iOS y Android.
> 
> En el puente JS, los importes del backend pasan por **`toNumber`** (strings como `"1964.45"` ya no rompen iOS), se añade **`updateWidgetSavings`** en clave aparte de `balance` (el bloque de ahorro del widget grande **solo se muestra** cuando Home publicó el resumen; si no, se oculta), y **`await updateWidgetBalance`** antes de `reloadWidgets` para evitar la carrera con el App Group. **`linking.ts`** registra `add`, `withdraw`, `send` y `savings` para que los deep links del widget naveguen de verdad.
> 
> En **Android**, `BalanceWidget` elige layout por tamaño (incl. `onAppWidgetOptionsChanged` en API &lt; 31), pinta el héroe en **bitmaps Rubik** con `tint` para night mode, y `SharedStorageModule` refresca también al escribir `savings`. Los widgets **P2P Ofertas/Tasas** quedan comentados en el manifest (código intacto).
> 
> En **iOS**, el balance pasa a small/medium/large con la misma paleta, Rubik en la extensión, lectura de ahorro opcional y `widgetDouble`; P2P widgets fuera del bundle comentando dos líneas. **`BalanceCard`** publica ahorros al widget cuando llega la query de resumen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c13d3c8cf0140f126d87a8a8e9a98146bea7dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->